### PR TITLE
feat: add udev rule to not track the T2-NCM interface via NetworkManager

### DIFF
--- a/scripts/fedora/install-networkmanager-rules.sh
+++ b/scripts/fedora/install-networkmanager-rules.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/lib.sh"
+
+require_root
+require_fedora
+
+readonly RULE_DIR="/etc/udev/rules.d"
+readonly RULE_FILE="$RULE_DIR/90-kait2en-t2-network.rules"
+
+info "installing NetworkManager exclusion for the internal T2 NCM interface"
+
+install -d -m 0755 "$RULE_DIR"
+
+cat >"$RULE_FILE" <<'EOF'
+# Apple T2 internal CDC-NCM interface.
+#
+# Do not match by MAC address or interface name:
+# both may differ between systems or naming-scheme versions.
+#
+# 05ac:8233 = Apple T2 Controller
+# cdc_ncm   = internal USB CDC-NCM network function
+ACTION=="add|change", SUBSYSTEM=="net", ENV{ID_BUS}=="usb", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="8233", DRIVERS=="cdc_ncm", ENV{NM_UNMANAGED}="1"
+EOF
+
+chmod 0644 "$RULE_FILE"
+
+udevadm control --reload-rules
+
+info "installed $RULE_FILE"
+info "the internal T2 network interface will be unmanaged after reboot"

--- a/scripts/fedora/install.sh
+++ b/scripts/fedora/install.sh
@@ -11,6 +11,7 @@ STEPS=(
 	install-dependencies.sh
 	install-kernel-args.sh
 	install-dkms-modules.sh
+	install-networkmanager-rules.sh
 	rebuild-initramfs.sh
 	install-suspend-service.sh
 	install-apps.sh


### PR DESCRIPTION
This PR adds a NetworkManager rule for Fedora that tells it not to manage the T2 NCM interface. That prevents NetworkManager from interfering with the T2-provided network device during setup and use. The change helps keep connectivity behavior more predictable on T2-equipped Macs.