### PR TITLE
t2-ncm: manage the internal debug interface via udev helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ of recompiling the kernel. Also users can profit quickly from the latest efforts
 
 It is not a separate distribution or a repackaged Fedora image. The
 base system is stock or T2linux Fedora. KaiT2en adds the missing T2-specific firmware
-steps, kernel arguments, DKMS modules and helper apps from this repository.
+steps, kernel arguments, DKMS modules and helper apps from this repository. It also
+installs small udev and systemd helpers for suspend quirks and to rename the internal
+T2 CDC-NCM debug interface to `t2_ncm` while keeping it out of normal networking.
 
 KaiT2en targets Fedora as a deliberate choice and "single source of truth" for
 development and debugging. Clean installs start from stock Fedora. Existing T2

--- a/howto/04-install-kait2en-modules-and-apps.md
+++ b/howto/04-install-kait2en-modules-and-apps.md
@@ -19,10 +19,12 @@ This runs all required installation steps in order:
 - Fedora dependencies
 - KaiT2en kernel arguments
 - KaiT2en DKMS modules
+- NetworkManager exclusion for the internal T2 CDC-NCM debug interface
+- systemd helper to keep the internal T2 CDC-NCM debug interface down
 - initramfs rebuild
+- KaiT2en suspend helper service
 - KaiT2en apps
 - react-drm, last and only on Touch Bar Macs
-- KaiT2en suspend helper service
 
 This will take a few minutes.
 Stay around to enter needed confirmations while the script is running.
@@ -44,6 +46,11 @@ after installation is finished.
 The installer also enables `kait2en-suspend.service`. It runs before suspend and
 after resume. The helper detects the local hardware and only applies fixes that
 match the machine.
+
+The installer also installs a udev rule that renames the internal Apple T2
+CDC-NCM interface to `t2_ncm` and tells NetworkManager to ignore it. A separate
+oneshot systemd service is started for that device and keeps it down because
+KaiT2en uses it only for debugging, not for normal networking.
 
 ## Suspend helper
 
@@ -69,3 +76,28 @@ and `hci_bcm4377` before suspend, then loads only the modules it unloaded after
 resume.
 
 If the helper does not detect matching hardware, it does not unload anything.
+
+## T2 CDC-NCM debug interface helper
+
+The T2 CDC-NCM debug interface helper is installed as:
+
+```text
+/etc/systemd/system/kait2en-t2-ncm-down.service # systemd service triggered for the debug interface
+/usr/local/libexec/kait2en/kait2en-t2-ncm-down.sh # actual script
+/etc/udev/rules.d/90-kait2en-t2-network.rules # NetworkManager exclusion
+```
+
+The source files in this repository are:
+
+```text
+systemd/kait2en-t2-ncm-down.service
+scripts/fedora/kait2en-t2-ncm-down.sh
+scripts/fedora/install-t2-ncm-debug-service.sh
+scripts/fedora/install-networkmanager-rules.sh
+```
+
+The udev rule detects the internal Apple T2 CDC-NCM interface by USB vendor and
+product ID plus the `cdc_ncm` driver, renames it to `t2_ncm`, marks it
+unmanaged for NetworkManager and asks systemd to start the helper service for
+that device. The helper then forces `t2_ncm` back down for a short retry window
+so late boot activity does not leave the debug interface up.

--- a/scripts/fedora/install-networkmanager-rules.sh
+++ b/scripts/fedora/install-networkmanager-rules.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/lib.sh"
+
+require_root
+require_fedora
+
+readonly RULE_DIR="/etc/udev/rules.d"
+readonly RULE_FILE="$RULE_DIR/90-kait2en-t2-network.rules"
+
+info "installing NetworkManager exclusion for the internal T2 NCM interface"
+
+install -d -m 0755 "$RULE_DIR"
+
+cat >"$RULE_FILE" <<'EOF'
+# Apple T2 internal CDC-NCM interface.
+#
+# Do not match by MAC address or interface name:
+# both may differ between systems or naming-scheme versions.
+#
+# 05ac:8233 = Apple T2 Controller
+# cdc_ncm   = internal USB CDC-NCM network function
+ACTION=="add|change", SUBSYSTEM=="net", ENV{ID_BUS}=="usb", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="8233", DRIVERS=="cdc_ncm", ENV{NM_UNMANAGED}="1"
+EOF
+
+chmod 0644 "$RULE_FILE"
+
+udevadm control --reload-rules
+
+info "installed $RULE_FILE"
+info "the internal T2 network interface will be unmanaged after reboot"

--- a/scripts/fedora/install-networkmanager-rules.sh
+++ b/scripts/fedora/install-networkmanager-rules.sh
@@ -20,7 +20,8 @@ cat >"$RULE_FILE" <<'EOF'
 #
 # 05ac:8233 = Apple T2 Controller
 # cdc_ncm   = internal USB CDC-NCM network function
-ACTION=="add|change", SUBSYSTEM=="net", ENV{ID_BUS}=="usb", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="8233", DRIVERS=="cdc_ncm", ENV{NM_UNMANAGED}="1"
+ACTION=="add", SUBSYSTEM=="net", ENV{ID_BUS}=="usb", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="8233", DRIVERS=="cdc_ncm", NAME:="t2_ncm", ENV{NM_UNMANAGED}="1", TAG+="systemd", ENV{SYSTEMD_WANTS}+="kait2en-t2-ncm-down.service"
+ACTION=="change", SUBSYSTEM=="net", KERNEL=="t2_ncm", ENV{NM_UNMANAGED}="1", TAG+="systemd", ENV{SYSTEMD_WANTS}+="kait2en-t2-ncm-down.service"
 EOF
 
 chmod 0644 "$RULE_FILE"
@@ -28,4 +29,4 @@ chmod 0644 "$RULE_FILE"
 udevadm control --reload-rules
 
 info "installed $RULE_FILE"
-info "the internal T2 network interface will be unmanaged after reboot"
+info "the internal T2 debug network interface will be renamed to t2_ncm and unmanaged after reboot"

--- a/scripts/fedora/install-t2-ncm-debug-service.sh
+++ b/scripts/fedora/install-t2-ncm-debug-service.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/lib.sh"
+
+require_root
+require_repo_root
+require_fedora
+require_command install systemctl
+
+SERVICE_SRC="$REPO_ROOT/systemd/kait2en-t2-ncm-down.service"
+SCRIPT_SRC="$REPO_ROOT/scripts/fedora/kait2en-t2-ncm-down.sh"
+
+[[ -f "$SERVICE_SRC" ]] || fail "missing $SERVICE_SRC"
+[[ -f "$SCRIPT_SRC" ]] || fail "missing $SCRIPT_SRC"
+
+info "installing Kait2en T2 CDC-NCM debug interface helper"
+install -d -o root -g root -m 0755 /usr/local/libexec/kait2en
+install -o root -g root -m 0755 "$SCRIPT_SRC" /usr/local/libexec/kait2en/kait2en-t2-ncm-down.sh
+install -o root -g root -m 0644 "$SERVICE_SRC" /etc/systemd/system/kait2en-t2-ncm-down.service
+
+systemctl disable kait2en-t2-ncm-down.service >/dev/null 2>&1 || true
+systemctl daemon-reload
+
+info "Kait2en T2 CDC-NCM debug interface helper installed"

--- a/scripts/fedora/install.sh
+++ b/scripts/fedora/install.sh
@@ -11,6 +11,7 @@ STEPS=(
 	install-dependencies.sh
 	install-kernel-args.sh
 	install-dkms-modules.sh
+	install-networkmanager-rules.sh
 	rebuild-initramfs.sh
 	install-suspend-service.sh
 	install-apps.sh

--- a/scripts/fedora/install.sh
+++ b/scripts/fedora/install.sh
@@ -12,6 +12,7 @@ STEPS=(
 	install-kernel-args.sh
 	install-dkms-modules.sh
 	install-networkmanager-rules.sh
+	install-t2-ncm-debug-service.sh
 	rebuild-initramfs.sh
 	install-suspend-service.sh
 	install-apps.sh

--- a/scripts/fedora/kait2en-t2-ncm-down.sh
+++ b/scripts/fedora/kait2en-t2-ncm-down.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -u
+
+LOG_TAG="kait2en-t2-ncm"
+TARGET_IFACE="t2_ncm"
+WAIT_ATTEMPTS=40
+WAIT_INTERVAL_SECS="0.25"
+
+log() {
+	printf '[%s] %s\n' "$LOG_TAG" "$*"
+}
+
+interface_exists() {
+	[[ -e "/sys/class/net/$1" ]]
+}
+
+wait_for_interface() {
+	local iface=$1
+	local attempt
+
+	for attempt in $(seq 1 "$WAIT_ATTEMPTS"); do
+		if interface_exists "$iface"; then
+			return 0
+		fi
+		sleep "$WAIT_INTERVAL_SECS"
+	done
+
+	return 1
+}
+
+interface_is_up() {
+	local iface=$1
+
+	ip -o link show dev "$iface" 2>/dev/null | grep -q '<[^>]*UP[,>]'
+}
+
+ensure_down_once() {
+	local iface=$1
+
+	log "setting $iface down"
+	if ! ip link set dev "$iface" down; then
+		log "could not set $iface down"
+		return 1
+	fi
+
+	return 0
+}
+
+ensure_down_stable() {
+	local iface=$1
+	local attempt
+
+	if ! wait_for_interface "$iface"; then
+		log "$iface did not appear in time"
+		return 0
+	fi
+
+	for attempt in $(seq 1 "$WAIT_ATTEMPTS"); do
+		if interface_is_up "$iface"; then
+			ensure_down_once "$iface" || true
+		fi
+		sleep "$WAIT_INTERVAL_SECS"
+	done
+
+	if interface_is_up "$iface"; then
+		log "$iface is still up after retries"
+		return 1
+	fi
+
+	log "$iface is down"
+	return 0
+}
+
+main() {
+	ensure_down_stable "$TARGET_IFACE"
+}
+
+main

--- a/systemd/kait2en-t2-ncm-down.service
+++ b/systemd/kait2en-t2-ncm-down.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Kait2en T2 CDC-NCM debug interface shutdown
+BindsTo=sys-subsystem-net-devices-t2_ncm.device
+After=sys-subsystem-net-devices-t2_ncm.device NetworkManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/libexec/kait2en/kait2en-t2-ncm-down.sh


### PR DESCRIPTION
This PR adds dedicated handling for the internal Apple T2 CDC-NCM debug interface on Fedora. It renames the interface to t2_ncm, marks it unmanaged for NetworkManager, and uses a udev-triggered systemd helper to keep it down reliably during boot.
This makes the interface clearly identifiable as a non-user-facing debug device and avoids it showing up as a normal network interface. The installer and documentation are updated accordingly.

This PR supersedes my other PR