### PR TITLE
hid_t2magicmouse, t2touchbar: fix build against kernel 7.1

### DIFF
--- a/modules/hid_t2magicmouse/hid_t2magicmouse.c
+++ b/modules/hid_t2magicmouse/hid_t2magicmouse.c
@@ -1440,9 +1440,12 @@ static int magicmouse_fetch_battery(struct hid_device *hdev)
 	struct hid_report_enum *report_enum;
 	struct hid_report *report;
 
-	if (!hdev->battery ||
-	    (!is_usb_magicmouse2(hdev->vendor, hdev->product) &&
+	if ((!is_usb_magicmouse2(hdev->vendor, hdev->product) &&
 	     !is_usb_magictrackpad2(hdev->vendor, hdev->product)))
+		return -1;
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 0)
+	if (!hdev->battery)
 		return -1;
 
 	report_enum = &hdev->report_enum[hdev->battery_report_type];
@@ -1453,6 +1456,21 @@ static int magicmouse_fetch_battery(struct hid_device *hdev)
 
 	if (hdev->battery_capacity == hdev->battery_max)
 		return -1;
+#else
+	struct hid_battery *battery = hid_get_battery(hdev);
+
+	if (!battery)
+		return -1;
+
+	report_enum = &hdev->report_enum[battery->report_type];
+	report = report_enum->report_id_hash[battery->report_id];
+
+	if (!report || report->maxfield < 1)
+		return -1;
+
+	if (battery->capacity == battery->max)
+		return -1;
+#endif
 
 	hid_hw_request(hdev, report, HID_REQ_GET_REPORT);
 	return 0;

--- a/modules/t2touchbar/t2hid.c
+++ b/modules/t2touchbar/t2hid.c
@@ -24,6 +24,7 @@
 #include <linux/slab.h>
 #include <linux/timer.h>
 #include <linux/string.h>
+#include <linux/version.h>
 #include <linux/leds.h>
 #include <dt-bindings/leds/common.h>
 
@@ -624,7 +625,11 @@ static int apple_fetch_battery(struct hid_device *hdev)
 	struct hid_report_enum *report_enum;
 	struct hid_report *report;
 
-	if (!(asc->quirks & APPLE_RDESC_BATTERY) || !hdev->battery)
+	if (!(asc->quirks & APPLE_RDESC_BATTERY))
+		return -1;
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 0)
+	if (!hdev->battery)
 		return -1;
 
 	report_enum = &hdev->report_enum[hdev->battery_report_type];
@@ -635,6 +640,21 @@ static int apple_fetch_battery(struct hid_device *hdev)
 
 	if (hdev->battery_capacity == hdev->battery_max)
 		return -1;
+#else
+	struct hid_battery *battery = hid_get_battery(hdev);
+
+	if (!battery)
+		return -1;
+
+	report_enum = &hdev->report_enum[battery->report_type];
+	report = report_enum->report_id_hash[battery->report_id];
+
+	if (!report || report->maxfield < 1)
+		return -1;
+
+	if (battery->capacity == battery->max)
+		return -1;
+#endif
 
 	hid_hw_request(hdev, report, HID_REQ_GET_REPORT);
 	return 0;


### PR DESCRIPTION
Kernel 7.1 replaced struct hid_device's single battery_* fields with a batteries list (struct hid_battery + hid_get_battery()), breaking DKMS builds of both modules on that kernel and leaving keyboard/trackpad/mouse without a driver. Add a LINUX_VERSION_CODE(7,1,0) guard so both the old and new battery API are supported.