### PR TITLE
Fixed touchbar asset paths issue

### DIFF
--- a/apps/react-drm/linux-touchbar-control-center/layers/mediaScreen.tsx
+++ b/apps/react-drm/linux-touchbar-control-center/layers/mediaScreen.tsx
@@ -13,8 +13,15 @@ import {
 import { BackButton } from '../components/BackButton';
 import { keys } from '../services/keyInjector';
 
-const KBD_ILLUM_DOWN_ICON = path.join(__dirname, '..', 'assets', 'kbd_illum_down.svg');
-const KBD_ILLUM_UP_ICON = path.join(__dirname, '..', 'assets', 'kbd_illum_up.svg');
+const isBuilt = __dirname.includes(path.sep + 'dist' + path.sep);
+
+const KBD_ILLUM_DOWN_ICON = isBuilt
+  ? path.join(__dirname, '..', '..', 'assets', 'kbd_illum_down.svg')
+  : path.join(__dirname, '..', 'assets', 'kbd_illum_down.svg');
+
+const KBD_ILLUM_UP_ICON = isBuilt
+  ? path.join(__dirname, '..', '..', 'assets', 'kbd_illum_up.svg')
+  : path.join(__dirname, '..', 'assets', 'kbd_illum_up.svg');
 
 // ── Actions ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
When running the compiled application via the systemd user service, the executing script runs out of the `dist/layers/` directory. The original path calculation (`path.join(__dirname, '..', 'assets')`) looks for assets inside a non-existent `dist/assets/` folder, causing the keyboard illumination icons to fail to render on the touch bar.

I added a simple environment check (`isBuilt`) to look for the presence of the `dist` directory path structure. 

* If running from the compiled production code, it steps up two directory levels to reach the root asset repository.
* If running in development it falls back to the original layout paths.

The back-light control icons now render properly on startup.