### PR TITLE
docs: fix broken relative link breaking mkdocs --strict build

### DIFF
--- a/howto/installation/manual/01-prepare-macos-and-fedora-usb.md
+++ b/howto/installation/manual/01-prepare-macos-and-fedora-usb.md
@@ -11,7 +11,7 @@ Internal input devices won't work during installation of Fedora,
 because the stock kernel does not contain the needed drivers.
 We will add them in a later step.
 
-If you don't have external input devices follow the [automatic installation](howto/installation/automatic/index.md)
+If you don't have external input devices follow the [automatic installation](../automatic/index.md)
 guide instead. It provides support for internal input devices.
 
 In effect, an external keyboard and mouse is mandatory for this step.


### PR DESCRIPTION
The "Deploy docs" Action runs mkdocs build --strict, which fails hard on any broken-link warning. 01-prepare-macos-and-fedora-usb.md linked to "howto/installation/automatic/index.md" as if relative to docs_dir, but mkdocs resolves relative links relative to the current file's directory (howto/installation/manual/), so it never resolved. 

Fixed to "../automatic/index.md" and verified with a local strict build.