### PR TITLE
Add missing 16,2 mic DSP profile with amp/compressor/limiter chain

### DIFF
--- a/modules/t2bce_audio-dsp/firs/16_2/mic.json
+++ b/modules/t2bce_audio-dsp/firs/16_2/mic.json
@@ -1,0 +1,135 @@
+{
+    "node.description": "MacBook Pro T2 DSP Mic",
+    "media.name": "MacBook Pro T2 DSP Mic",
+    "filter.graph": {
+        "nodes": [
+            {
+                "type": "builtin",
+                "label": "mixer",
+                "name": "mixL",
+                "control": {
+                    "Gain 1": 1.5
+                }
+            },
+            {
+                "type": "builtin",
+                "label": "mixer",
+                "name": "mixR",
+                "control": {
+                    "Gain 1": 1.5
+                }
+            },
+            {
+                "type": "builtin",
+                "label": "mixer",
+                "name": "mixO",
+                "control": {
+                    "Gain 1": 1
+                }
+            },
+            {
+                "type": "lv2",
+                "plugin": "https://chadmed.au/triforce",
+                "name": "bf",
+                "control": {
+                    "h_angle": 230.0,
+                    "v_angle": 0.0,
+                    "opt_freq": 1100.0,
+                    "t_win": 500.0,
+                    "mic2_x": 0.02,
+                    "mic2_y": 0.00,
+                    "mic3_x": 0.01,
+                    "mic3_y": 0.0173
+                }
+            },
+            {
+                "type": "ladspa",
+                "plugin": "amp_1181",
+                "label": "amp",
+                "name": "preamp",
+                "control": {
+                    "Amps gain (dB)": 35
+                }
+            },
+            {
+                "type": "builtin",
+                "label": "bq_highpass",
+                "name": "hpf",
+                "control": {
+                    "Freq": 120,
+                    "Gain": 1,
+                    "Q": 0.707
+                }
+            },
+            {
+                "type": "ladspa",
+                "plugin": "sc4_1882",
+                "label": "sc4",
+                "name": "compressor",
+                "control": {
+                    "RMS/peak": 0,
+                    "Attack time (ms)": 50,
+                    "Release time (ms)": 300,
+                    "Threshold level (dB)": -12,
+                    "Ratio (1:n)": 4,
+                    "Knee radius (dB)": 3,
+                    "Makeup gain (dB)": 5
+                }
+            },
+            {
+                "type": "ladspa",
+                "plugin": "fast_lookahead_limiter_1913",
+                "label": "fastLookaheadLimiter",
+                "name": "lim",
+                "control": {
+                    "Input gain (dB)": 0,
+                    "Limit (dB)": -1,
+                    "Release time (s)": 0.8
+                }
+            }
+        ],
+        "links": [
+            {"output": "mixL:Out", "input": "bf:in_1"},
+            {"output": "mixR:Out", "input": "bf:in_2"},
+            {"output": "mixO:Out", "input": "bf:in_3"},
+            {"output": "bf:out", "input": "preamp:Input"},
+            {"output": "preamp:Output", "input": "hpf:In"},
+            {"output": "hpf:Out", "input": "compressor:Left input"},
+            {"output": "compressor:Left output", "input": "lim:Input 1"}
+        ],
+        "inputs": [
+            "mixL:In 1",
+            "mixR:In 1",
+            "mixO:In 1"
+        ],
+        "outputs": [
+            "lim:Output 1"
+        ]
+    },
+    "capture.props": {
+        "node.name": "effect_input.t2-162-mic",
+        "audio.position": ["AUX0", "AUX1", "AUX2"],
+        "audio.channels": "3",
+        "stream.dont-remix": "true",
+        "target.object": "alsa_input.pci-0000_04_00.3.BuiltinMic",
+        "node.passive": "true",
+        "node.pause-on-idle": "true",
+        "node.virtual": "false",
+        "state.default-volume": 1.00,
+        "audio.allowed-rates": [44100, 48000]
+    },
+    "playback.props": {
+        "node.name": "audio_effect.t2-162-mic",
+        "node.description": "MacBook Pro T2 DSP Mic",
+        "media.name": "MacBook Pro T2 DSP Mic",
+        "media.class": "Audio/Source",
+        "node.pause-on-idle": "true",
+        "audio.position": ["MONO"],
+        "audio.channels": "1",
+        "node.virtual": "false",
+        "priority.session": 850,
+        "state.default-volume": 1.0,
+        "audio.allowed-rates": [44100, 48000],
+        "device.icon-name": "audio-input-microphone"
+    }
+}


### PR DESCRIPTION
The internal mic on 16,2 was silent because, unlike 15,1/16,1/16,4, it had no mic.json DSP profile at all. 

After extensive testing, this PR adds one using a proven amp -> compressor > limiter chain, which gave much better results than simply raising the builtin mixer's gain.

With this configuration, the builtin mic is not just loud enough... it almost sounds better than my external RODE NT-USB mic.