### PR TITLE
react-drm: replace dynamic KWin script injection with D-Bus server for KDE active window detection

### DIFF
--- a/apps/react-drm/README.md
+++ b/apps/react-drm/README.md
@@ -99,7 +99,9 @@ installer deploys the required backend and react-drm selects it automatically:
 - GNOME Wayland uses
   [Window Monitor Pro](https://extensions.gnome.org/extension/8549/window-monitor-pro/),
   maintained by the react-drm developer
-- KDE Plasma Wayland uses KWin scripting
+- KDE Plasma Wayland uses
+  **TouchBar Dynamic Shortcuts**, a KWin script installed and enabled by
+  the KaiT2en installer
 - Hyprland uses its IPC socket
 - Xorg uses `xprop`
 

--- a/apps/react-drm/linux-touchbar-control-center/activeWindow/plasma.ts
+++ b/apps/react-drm/linux-touchbar-control-center/activeWindow/plasma.ts
@@ -1,54 +1,16 @@
-import { spawn, type ChildProcess } from 'child_process';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import dbus from 'dbus-next';
-import type { ActiveWindow, ActiveWindowBackend } from './types';
+import dbus, { Message } from 'dbus-next';
+import type { ActiveWindowBackend } from './types';
 
-// KDE Plasma Wayland via KWin scripting (~/active-window.sh, made push-based).
-// KWin exposes no D-Bus query for the focused window, but a *loaded* script can
-// hook workspace.windowActivated (and each window's captionChanged) and print
-// the focus state on every change. KWin routes print() to the journal, so we
-// inject a persistent script and tail journalctl for our marker lines.
+// KDE Plasma Wayland via the touchbar_dynamicshortcuts KWin script.
 //
-// KDE-on-Xorg is handled by the xorg backend (EWMH props over the X protocol);
-// this is only for the Wayland session, where that protocol is blocked.
+// The KWin script hooks workspace.windowActivated and pushes focus changes to
+// this backend over D-Bus (method calls on org.touchbar.DynamicShortcuts).
+// No journalctl, no dynamic script injection — the user enables the script
+// once in System Settings → Window Management → KWin Scripts.
 
-const SVC             = 'org.kde.KWin';
-const SCRIPTING_PATH  = '/Scripting';
-const SCRIPTING_IFACE = 'org.kde.kwin.Scripting';
-const SCRIPT_IFACE    = 'org.kde.kwin.Script';
-const PLUGIN          = 'react-drm-activewindow';
-
-// The injected KWin script: emit "<marker> class\ttitle\tpid" on the initial
-// focus and on every focus/title change. captionChanged catches terminals and
-// browsers retitling without moving focus (parity with the xorg backend).
-function scriptSource(marker: string): string {
-  const m = JSON.stringify(marker);
-  return `
-var active = null;
-function emit(w) {
-  if (w) print(${m} + " " + w.resourceClass + "\\t" + w.caption + "\\t" + w.pid);
-  else   print(${m} + " \\t\\t0");
-}
-function onCaption() { emit(active); }
-function onActivated(w) {
-  try { if (active) active.captionChanged.disconnect(onCaption); } catch (e) {}
-  active = w;
-  try { if (w) w.captionChanged.connect(onCaption); } catch (e) {}
-  emit(w);
-}
-workspace.windowActivated.connect(onActivated);
-onActivated(workspace.activeWindow);
-`;
-}
-
-// journalctl --since takes local "YYYY-MM-DD HH:MM:SS".
-function journalStamp(d: Date): string {
-  const p = (n: number) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ` +
-         `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
-}
+const SVC    = 'org.touchbar.DynamicShortcuts';
+const PATH   = '/org/touchbar/DynamicShortcuts';
+const IFACE  = 'org.touchbar.DynamicShortcuts';
 
 export const plasma: ActiveWindowBackend = {
   name: 'plasma (kwin-script)',
@@ -57,81 +19,31 @@ export const plasma: ActiveWindowBackend = {
     let bus: dbus.MessageBus;
     try { bus = dbus.sessionBus(); } catch { return null; }
 
-    let journal: ChildProcess | null = null;
-    let scriptFile: string | null = null;
-
     try {
-      // Is KWin on the bus? (Both Wayland and Xorg KDE own this name; the store
-      // only routes the Wayland session here.)
-      const dbusObj   = await bus.getProxyObject('org.freedesktop.DBus', '/org/freedesktop/DBus');
-      const dbusIface = dbusObj.getInterface('org.freedesktop.DBus');
-      if (!(await dbusIface.NameHasOwner(SVC))) throw new Error('no KWin');
+      const rc = await bus.requestName(SVC, 0);
+      // rc: 1 = PRIMARY_OWNER, 2 = IN_QUEUE, 3 = EXISTS, 4 = ALREADY_OWNER
+      if (rc !== 1 && rc !== 4) { bus.disconnect(); return null; }
 
-      const scripting = (await bus.getProxyObject(SVC, SCRIPTING_PATH)).getInterface(SCRIPTING_IFACE);
+      bus.addMethodHandler((msg: Message) => {
+        if (msg.path !== PATH || msg.interface !== IFACE) return false;
 
-      // Unique marker per run so a crashed previous run's journal lines can't be
-      // mistaken for ours.
-      const marker = `REACTDRM_ACTWIN_${process.pid}`;
-
-      // loadScript takes a file path. KWin runs as the user, so the file must be
-      // world-readable even when we're under sudo (root-owned 0600 would be
-      // unreadable to KWin) — same sudo-awareness as the other backends.
-      scriptFile = path.join(os.tmpdir(), `react-drm-actwin-${process.pid}.js`);
-      fs.writeFileSync(scriptFile, scriptSource(marker), { mode: 0o644 });
-
-      // Start following the journal *before* loading the script, anchored a
-      // second in the past, so the script's initial print() can't slip through
-      // before journalctl attaches.
-      const since = journalStamp(new Date(Date.now() - 1000));
-      const asRoot = typeof process.getuid === 'function' && process.getuid() === 0;
-      // Under sudo the per-user journal is root's; root can instead read the
-      // merged system journal, where KWin's output also lands.
-      const args = asRoot
-        ? ['-f', '-o', 'cat', '--since', since]
-        : ['--user', '-f', '-o', 'cat', '--since', since];
-      journal = spawn('journalctl', args);
-      journal.on('error', () => {}); // journalctl missing → no updates
-
-      let carry = '';
-      journal.stdout?.on('data', (chunk: Buffer) => {
-        carry += chunk.toString('utf8');
-        const lines = carry.split('\n');
-        carry = lines.pop() ?? '';
-        for (const line of lines) {
-          const i = line.indexOf(marker);
-          if (i < 0) continue;
-          const [klass = '', title = '', pid = '0'] = line.slice(i + marker.length + 1).split('\t');
-          push({ title, class: klass, pid: Number(pid) || 0 });
+        if (msg.member === 'SetActiveWindow') {
+          const klass = String(msg.body?.[0] ?? '');
+          const title = String(msg.body?.[1] ?? '');
+          push({ class: klass, title, pid: 0 });
+          bus.send(Message.newMethodReturn(msg, '', []));
+          return true;
         }
+
+        return false;
       });
 
-      // A stale instance from a crashed run would double every line — drop it.
-      if (await scripting.isScriptLoaded(PLUGIN).catch(() => false)) {
-        await scripting.unloadScript(PLUGIN).catch(() => {});
-      }
-
-      // loadScript is overloaded (loadScript(path) and loadScript(path, name));
-      // dbus-next binds the proxy to the single-arg signature, so call the
-      // two-arg form by hand to get a named plugin we can cleanly unload.
-      const reply = await bus.call(new dbus.Message({
-        destination: SVC, path: SCRIPTING_PATH, interface: SCRIPTING_IFACE,
-        member: 'loadScript', signature: 'ss', body: [scriptFile, PLUGIN],
-      }));
-      if (!reply) throw new Error('loadScript: no reply');
-      const id     = reply.body[0] as number;
-      const script = (await bus.getProxyObject(SVC, `${SCRIPTING_PATH}/Script${id}`)).getInterface(SCRIPT_IFACE);
-      await script.run();
-
       return () => {
-        journal?.kill();
-        scripting.unloadScript(PLUGIN).catch(() => {}).finally(() => bus.disconnect());
-        if (scriptFile) { try { fs.unlinkSync(scriptFile); } catch { /**/ } }
+        bus.disconnect();
       };
     } catch {
-      journal?.kill();
-      if (scriptFile) { try { fs.unlinkSync(scriptFile); } catch { /**/ } }
       bus.disconnect();
-      return null; // not KDE, or KWin scripting unavailable
+      return null;
     }
   },
 };

--- a/apps/react-drm/touchbar_dynamicshortcuts/contents/code/main.js
+++ b/apps/react-drm/touchbar_dynamicshortcuts/contents/code/main.js
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+function setActiveWindow(window) {
+    if (!window) {
+        return;
+    }
+    callDBus('org.touchbar.DynamicShortcuts',
+             '/org/touchbar/DynamicShortcuts',
+             'org.touchbar.DynamicShortcuts',
+             'SetActiveWindow',
+             window.resourceClass, window.caption);
+}
+
+if (workspace.windowActivated) {
+    workspace.windowActivated.connect(setActiveWindow);
+} else if (workspace.clientActivated) {
+    workspace.clientActivated.connect(setActiveWindow);
+}

--- a/apps/react-drm/touchbar_dynamicshortcuts/metadata.json
+++ b/apps/react-drm/touchbar_dynamicshortcuts/metadata.json
@@ -1,0 +1,17 @@
+{
+    "KPackageStructure": "KWin/Script",
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "yossefgamer24@yahoo.com",
+                "Name": "Yossef Osman"
+            }
+        ],
+        "Description": "Reports active window info to react-drm via D-Bus",
+        "Icon": "preferences-system-windows",
+        "Id": "touchbar_dynamicshortcuts",
+        "License": "GPL-3.0-only",
+        "Name": "TouchBar Dynamic Shortcuts"
+    },
+    "X-Plasma-API": "javascript"
+}

--- a/scripts/fedora/install-apps.sh
+++ b/scripts/fedora/install-apps.sh
@@ -175,6 +175,21 @@ install_react_drm() {
 		fi
 	fi
 
+	if [[ "$desktop" == *kde* || "$desktop" == *plasma* ]]; then
+		require_command kpackagetool6 kwriteconfig6 qdbus
+		kwin_script_src="$src/touchbar_dynamicshortcuts"
+		for package in metadata.json contents/code/main.js; do
+			[[ -r "$kwin_script_src/$package" ]] ||
+				fail "react-drm KWin script file is missing: $package"
+		done
+		info "installing TouchBar Dynamic Shortcuts KWin script for react-drm"
+		run_as_target kpackagetool6 --type=KWin/Script -r touchbar_dynamicshortcuts || true
+		run_as_target kpackagetool6 --type=KWin/Script -i "$kwin_script_src"
+		run_as_target kwriteconfig6 --file kwinrc --group Plugins \
+			--key touchbar_dynamicshortcutsEnabled true
+		run_as_target qdbus org.kde.KWin /KWin reconfigure
+	fi
+
 	info "installing react-drm Fedora dependencies"
 	for package in "${REACT_DRM_FEDORA_NODE_PACKAGES[@]}"; do
 		if rpm -q "$package" >/dev/null 2>&1; then


### PR DESCRIPTION
The plasma backend previously generated a KWin script at runtime and tailed journalctl for focus events, which was unreliable if on kde 5 and doesn't work on kde 6. Replace it with a D-Bus server that the pre-installed touchbar_dynamicshortcuts KWin script (based on the ktouchbar project) pushes to directly.

Also adds KWin script auto-installation to the KaiT2en installer for KDE/Plasma sessions, matching the existing GNOME extension pattern.

- Rewrite plasma.ts as a D-Bus service (addMethodHandler)
- Reuse ktouchbar KWin script and rename to touchbar_dynamicshortcuts
- Add KDE block to install-apps.sh (kpackagetool6 + kwriteconfig6)
- Update README with KWin script details