### PR TITLE
installer: force the input drivers into the stage 2 initramfs

### DIFF
--- a/packaging/installer/runtime/kait2en-prepare
+++ b/packaging/installer/runtime/kait2en-prepare
@@ -231,7 +231,10 @@ done
 
 depmod -a "$target_kernel"
 initramfs="$boot_root/initramfs-$target_kernel.img"
-dracut --force --add-drivers "${input_modules[*]}" "$initramfs" "$target_kernel"
+# The modules are removed from the disk below, so the initramfs is their only
+# copy on the next boot. Their modalias only appears around the switch root, so
+# force the load before udev instead of racing it.
+dracut --force --force-drivers "${input_modules[*]}" "$initramfs" "$target_kernel"
 listing=$(lsinitrd "$initramfs")
 for module in "${input_modules[@]}"; do
 	grep -Eq "/${module}\.ko(\.[a-z0-9]+)?$" <<<"$listing" ||

--- a/tests/installer/prepare-install.sh
+++ b/tests/installer/prepare-install.sh
@@ -128,6 +128,10 @@ run_prepare 0 "$old" >/dev/null
 grep -Fq 'dnf upgrade --refresh -y --setopt=installonly_limit=0' "$log"
 grep -Fq "install-dependencies $target" "$log"
 grep -Fq "build-input-kmod kernel=$target arguments=3" "$log"
+# Forced, not merely added: the modules are deleted from the disk below.
+grep -Fq \
+	'dracut --force --force-drivers t2bce_dma t2hid hid_t2magicmouse t2bce_core t2bce_vhci' \
+	"$log"
 grep -Fq 'rpm -e kmod-kait2en-input' "$log"
 [[ ! -d "$fake_modules/$target/updates/kait2en-transition" ]]
 [[ $(tail -n 1 "$log") == "grubby --set-default $fake_boot/vmlinuz-$target" ]]

--- a/tests/installer/static-check.sh
+++ b/tests/installer/static-check.sh
@@ -55,6 +55,10 @@ done < <(git ls-files 'packaging/installer/anaconda-addon/*.py' \
 	packaging/installer/runtime/kait2en-prepare
 grep -Fq '"$transition_source" "$target_kernel" "$work/rpm"' \
 	packaging/installer/runtime/kait2en-prepare
+# The transition modules only live in the initramfs, so they must be forced in.
+grep -Fq 'dracut --force --force-drivers' \
+	packaging/installer/runtime/kait2en-prepare
+! grep -Fq -- '--add-drivers' packaging/installer/runtime/kait2en-prepare
 grep -Fq '"etc", "xdg", "autostart"' \
 	packaging/installer/anaconda-addon/com_kait2en_input/service/installation.py
 ! rg -n 'find_regular_user|home\.lstrip|os\.chown' \


### PR DESCRIPTION
`kait2en-prepare` deletes the transition modules from disk right after baking them into the initramfs, so the image is their only copy on the next boot. 
But `--add-drivers` leaves loading to each device's modalias, and the topcase only enumerates within milliseconds of the switch root. 
By then the request reaches the real root, where the modules are gone. `--force-drivers` loads them before the udev coldplug instead.

Verified on a MacBook Pro 16,2: `t2hid` binds the topcase at 2.5 s instead of
12.0 s, i.e. ~7 s before the switch root.