### PR TITLE
docs: fix the feature board filter on narrow screens

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -205,6 +205,10 @@
   background: #121517;
 }
 
+.md-typeset .board-table tr[hidden] {
+  display: none;
+}
+
 .board-cell-state,
 .board-cell-upstream,
 .board-cell-updated {


### PR DESCRIPTION
This fixes the non-working feature-board filtering option on mobile devices with narrow screens