### PR TITLE
docs: explain what KAIT2EN is on the docs home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,10 @@
 
 # KAIT2EN Fedora Documentation
 
+KAIT2EN brings cutting edge T2 Mac support to stock Fedora using DKMS modules.
+You will receive kernel updates directly from Fedora and the latest T2 modules
+from us.
+
 [GitHub repository](https://github.com/kaiT2en/KaiT2en-Fedora)
 
 ## Documentation


### PR DESCRIPTION
The docs landing page opened straight into a link list, so a first-time visitor had no one-line answer to what KAIT2EN is or who it is for. Add the intro sentences from the README above the links.