### PR TITLE
installer: add GRUB troubleshooting entries for Macs that fail to boot

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -112,6 +112,25 @@ format an existing Linux `/boot` partition so old kernels do not fill it.
 After installation finishes, remove the USB drive and boot the installed Fedora
 system.
 
+### If the live system does not start
+
+The boot menu offers a few troubleshooting entries that are only needed when the
+normal boot does not work. Try them in this order and stop at the first one that
+works:
+
+1. `Troubleshooting: KaiT2en with boot messages` shows the console instead of
+   the logo. Photograph the last lines for a bug report.
+2. `Troubleshooting: KaiT2en with the dedicated GPU disabled` keeps `amdgpu`
+   out of the boot and leaves the Intel GPU fully accelerated.
+3. `Troubleshooting: KaiT2en with basic graphics` adds `nomodeset`. Rendering
+   is done in software and feels slow, but it can run the installation.
+4. `Troubleshooting: KaiT2en with basic graphics and conservative PCIe` is the
+   last resort and also covers a power off coming from PCIe or Thunderbolt.
+
+All of them keep the KAIT2EN input drivers. If entry 2 or 3 was needed, make
+the fix permanent afterwards as described in
+[Configure GPUs](post-install/configuring-gpus.md).
+
 ### If hardware is missing in the live system
 
 KAIT2EN supports the known T2 configurations, but Apple shipped several

--- a/packaging/installer/build-in-container.sh
+++ b/packaging/installer/build-in-container.sh
@@ -296,6 +296,9 @@ gzip -dc "$INITRAMFS_IMAGE" | cpio -it --quiet |
 grep -Fq 'inst.updates=file:///run/kait2en/updates.img' "$LAYOUT/grub.cfg.in"
 grep -Fq '@ISO_VOLUME_LABEL@' "$LAYOUT/grub.cfg.in"
 ! grep -Fq 'inst.ks=' "$LAYOUT/grub.cfg.in"
+grep -Fq 'module_blacklist=${kait2en_blacklist},amdgpu' "$LAYOUT/grub.cfg.in"
+grep -Fq 'plymouth.enable=0' "$LAYOUT/grub.cfg.in"
+grep -Fq 'nomodeset' "$LAYOUT/grub.cfg.in"
 rm -f "$UPDATES_IMAGE"
 
 printf 'TARGET_ID=%q\nFEDORA_RELEASE=%q\nDEFAULT_EDITION=%q\nISO_KERNEL_RELEASE=%q\nANACONDA_VERSION=%q\n' \

--- a/packaging/installer/grub.cfg.in
+++ b/packaging/installer/grub.cfg.in
@@ -8,12 +8,40 @@ terminal_output console
 set kait2en_efi=$root
 search --no-floppy --label --set=fedora @ISO_VOLUME_LABEL@
 
+# Must be set after the search line: GRUB expands these at assignment time.
+set kait2en_common="root=live:CDLABEL=@ISO_VOLUME_LABEL@ rd.live.image inst.updates=file:///run/kait2en/updates.img initcall_blacklist=magicmouse_driver_init"
+set kait2en_blacklist="acpi_tad,applesmc,macsmc,hid_apple,hid_appletb_bl,hid_appletb_kbd,hid_magicmouse,appletbdrm,apple_bce,apple_mfi_fastcharge,apple_gmux"
+set kait2en_initrd="($fedora)@ISO_INITRD_PATH@ ($kait2en_efi)/EFI/BOOT/kait2en/kait2en-input-initramfs.img ($kait2en_efi)/EFI/BOOT/kait2en/kait2en-wifi-initramfs.img"
+
 menuentry "Start Fedora Live with KaiT2en input drivers" --class fedora --class gnu-linux --class gnu --class os {
-	linux ($fedora)@ISO_KERNEL_PATH@ quiet rhgb root=live:CDLABEL=@ISO_VOLUME_LABEL@ rd.live.image inst.updates=file:///run/kait2en/updates.img initcall_blacklist=magicmouse_driver_init module_blacklist=acpi_tad,applesmc,macsmc,hid_apple,hid_appletb_bl,hid_appletb_kbd,hid_magicmouse,appletbdrm,apple_bce,apple_mfi_fastcharge,apple_gmux
-	initrd ($fedora)@ISO_INITRD_PATH@ ($kait2en_efi)/EFI/BOOT/kait2en/kait2en-input-initramfs.img ($kait2en_efi)/EFI/BOOT/kait2en/kait2en-wifi-initramfs.img
+	linux ($fedora)@ISO_KERNEL_PATH@ quiet rhgb ${kait2en_common} module_blacklist=${kait2en_blacklist}
+	initrd ${kait2en_initrd}
 }
 
 menuentry "Start standard Fedora Live" --class fedora --class gnu-linux --class gnu --class os {
 	linux ($fedora)@ISO_KERNEL_PATH@ quiet rhgb root=live:CDLABEL=@ISO_VOLUME_LABEL@ rd.live.image
 	initrd ($fedora)@ISO_INITRD_PATH@
+}
+
+# Apple firmware gives GRUB no Ctrl-X or F10, so boot options cannot be edited
+# on a T2 Mac and every option set needs its own entry.
+
+menuentry "Troubleshooting: KaiT2en with boot messages" --class fedora --class gnu-linux --class gnu --class os {
+	linux ($fedora)@ISO_KERNEL_PATH@ ${kait2en_common} module_blacklist=${kait2en_blacklist} plymouth.enable=0
+	initrd ${kait2en_initrd}
+}
+
+menuentry "Troubleshooting: KaiT2en with the dedicated GPU disabled" --class fedora --class gnu-linux --class gnu --class os {
+	linux ($fedora)@ISO_KERNEL_PATH@ ${kait2en_common} module_blacklist=${kait2en_blacklist},amdgpu plymouth.enable=0
+	initrd ${kait2en_initrd}
+}
+
+menuentry "Troubleshooting: KaiT2en with basic graphics" --class fedora --class gnu-linux --class gnu --class os {
+	linux ($fedora)@ISO_KERNEL_PATH@ ${kait2en_common} module_blacklist=${kait2en_blacklist} plymouth.enable=0 nomodeset
+	initrd ${kait2en_initrd}
+}
+
+menuentry "Troubleshooting: KaiT2en with basic graphics and conservative PCIe" --class fedora --class gnu-linux --class gnu --class os {
+	linux ($fedora)@ISO_KERNEL_PATH@ ${kait2en_common} module_blacklist=${kait2en_blacklist},amdgpu plymouth.enable=0 nomodeset pcie_ports=compat
+	initrd ${kait2en_initrd}
 }

--- a/tests/installer/static-check.sh
+++ b/tests/installer/static-check.sh
@@ -55,6 +55,14 @@ done < <(git ls-files 'packaging/installer/anaconda-addon/*.py' \
 	scripts/macos
 ! rg -n 'brcmfmac(4364|4377).*alias|generic.*brcmfmac|brcmfmac[^ ]*-pcie\.txt' \
 	packaging/installer
+# A KaiT2en entry without the input initramfs loses the keyboard it rescues.
+awk '
+$1 == "linux" && index($0, "${kait2en_common}") { entries++ }
+$1 == "initrd" && $2 == "${kait2en_initrd}" { overlays++ }
+END { exit !(entries >= 5 && entries == overlays) }
+' packaging/installer/grub.cfg.in
+grep -Fq 'plymouth.enable=0' packaging/installer/grub.cfg.in
+grep -Fq 'nomodeset' packaging/installer/grub.cfg.in
 ! rg -n 'INPUT_COMPAT_PATCH|compat_patch|packaging/installer/patches' \
 	packaging/installer/runtime/kait2en-prepare
 grep -Fq '"$transition_source" "$target_kernel" "$work/rpm"' \


### PR DESCRIPTION
Since you can't actually use Grub to modify boot entries on a T2 mac since F10 and ctrl+x both don't work in grub, I'll add some debug boot entries, which could be handy to troubleshoot stuff.