### PR TITLE
installer: stop blacklisting apple_gmux in the live system

### DIFF
--- a/packaging/installer/grub.cfg.in
+++ b/packaging/installer/grub.cfg.in
@@ -10,7 +10,7 @@ search --no-floppy --label --set=fedora @ISO_VOLUME_LABEL@
 
 # Must be set after the search line: GRUB expands these at assignment time.
 set kait2en_common="root=live:CDLABEL=@ISO_VOLUME_LABEL@ rd.live.image inst.updates=file:///run/kait2en/updates.img initcall_blacklist=magicmouse_driver_init"
-set kait2en_blacklist="acpi_tad,applesmc,macsmc,hid_apple,hid_appletb_bl,hid_appletb_kbd,hid_magicmouse,appletbdrm,apple_bce,apple_mfi_fastcharge,apple_gmux"
+set kait2en_blacklist="acpi_tad,applesmc,macsmc,hid_apple,hid_appletb_bl,hid_appletb_kbd,hid_magicmouse,appletbdrm,apple_bce,apple_mfi_fastcharge"
 set kait2en_initrd="($fedora)@ISO_INITRD_PATH@ ($kait2en_efi)/EFI/BOOT/kait2en/kait2en-input-initramfs.img ($kait2en_efi)/EFI/BOOT/kait2en/kait2en-wifi-initramfs.img"
 
 menuentry "Start Fedora Live with KaiT2en input drivers" --class fedora --class gnu-linux --class gnu --class os {

--- a/tests/installer/static-check.sh
+++ b/tests/installer/static-check.sh
@@ -63,6 +63,9 @@ END { exit !(entries >= 5 && entries == overlays) }
 ' packaging/installer/grub.cfg.in
 grep -Fq 'plymouth.enable=0' packaging/installer/grub.cfg.in
 grep -Fq 'nomodeset' packaging/installer/grub.cfg.in
+if grep -Eq '^set kait2en_blacklist=.*apple_gmux' packaging/installer/grub.cfg.in; then
+	exit 1
+fi
 ! rg -n 'INPUT_COMPAT_PATCH|compat_patch|packaging/installer/patches' \
 	packaging/installer/runtime/kait2en-prepare
 grep -Fq '"$transition_source" "$target_kernel" "$work/rpm"' \


### PR DESCRIPTION
remove apple_gmux from the blacklist of the Live ISO