### PR TITLE
installer: refuse a DKMS run for a kernel without headers

### DIFF
--- a/scripts/fedora/install-dkms-modules.sh
+++ b/scripts/fedora/install-dkms-modules.sh
@@ -6,6 +6,10 @@ require_root
 require_repo_root
 require_fedora
 require_command dkms make install rm chown mktemp depmod sed tar find grep
+# Every module is removed for every kernel below before anything is rebuilt, so
+# a kernel that cannot be built for has to stop the script here. Discovering it
+# at the first compile would leave every kernel with nothing installed.
+require_kernel_headers
 
 MODULES=(
 	t2bce_dma

--- a/scripts/fedora/lib.sh
+++ b/scripts/fedora/lib.sh
@@ -46,6 +46,16 @@ kernel_release() {
 	printf '%s\n' "${KERNEL_RELEASE:-$(uname -r)}"
 }
 
+require_kernel_headers() {
+	local release
+	# install_module calls dkms without -k, so the build always targets the
+	# running kernel whatever KERNEL_RELEASE says.
+	release="$(uname -r)"
+
+	[[ -d "/lib/modules/$release/build" ]] ||
+		fail "kernel-devel-$release is missing; run install-dependencies.sh first"
+}
+
 require_min_kernel() {
 	local min_major=$1 min_minor=$2 release major minor
 

--- a/tests/installer/static-check.sh
+++ b/tests/installer/static-check.sh
@@ -21,6 +21,7 @@ shell_files=(
 	packaging/installer/runtime/kait2en-prepare
 	scripts/fedora/build-installer.sh
 	scripts/fedora/install-dkms-modules.sh
+	scripts/fedora/lib.sh
 	scripts/macos/download-fedora-iso.sh
 	scripts/macos/prepare-fedora-installer.sh
 	tests/installer/edition-catalog.sh
@@ -76,6 +77,11 @@ grep -Fq '"$transition_source" "$target_kernel" "$work/rpm"' \
 grep -Fq 'dracut --force --force-drivers' \
 	packaging/installer/runtime/kait2en-prepare
 ! grep -Fq -- '--add-drivers' packaging/installer/runtime/kait2en-prepare
+
+# DKMS drops every kernel's build before rebuilding any of them, so a kernel
+# without headers has to be refused before anything is removed.
+grep -Fq 'require_kernel_headers' scripts/fedora/install-dkms-modules.sh
+grep -Fq 'require_kernel_headers()' scripts/fedora/lib.sh
 grep -Fq '"etc", "xdg", "autostart"' \
 	packaging/installer/anaconda-addon/com_kait2en_input/service/installation.py
 ! grep -InE 'find_regular_user|home\.lstrip|os\.chown' \


### PR DESCRIPTION
### Problem

`install-dkms-modules.sh` removes every module for **every** kernel before it builds anything:

```
114:  dkms remove --no-depmod -m "$name" -v "$version" --all      # --all = all kernels
268:  dkms add     -m "$name" -v "$version"
269:  dkms build   -m "$name" -v "$version"                        # no -k → running kernel
270:  dkms install --no-depmod --force -m "$name" -v "$version"
```

The guards are `require_root`, `require_fedora` and `require_command` — nothing checks that the running kernel can actually be built for. So on a kernel without `kernel-devel`, the script deletes the working builds for every other kernel and then fails at the first compile, leaving nothing installed.

I hit this on a machine still booted on the pre-upgrade kernel. Fedora leaves the symlink in place when `kernel-devel` is absent, so it looks fine until you resolve it:

```
6.19.10-300.fc44.x86_64  build -> /usr/src/kernels/6.19.10-300.fc44.x86_64   dangling
7.1.7-200.fc44.x86_64    build -> /usr/src/kernels/7.1.7-200.fc44.x86_64     resolves
```

That dangling link is also what makes `dkms.service` fail at boot on such a system.

### Fix

`require_kernel_headers` in `lib.sh`, called before anything destructive runs. The check is `[[ -d ".../build/." ]]` — the trailing component forces symlink resolution, since plain `-e` or `-d` on the link itself passes even when it dangles.

### Notes

- No behaviour change in the normal flow: `install.sh` runs `install-dependencies.sh` (step 1), which installs `kernel-devel`, well before `install-dkms-modules.sh` (step 3).
- The change is only visible when the script is run standalone on a kernel it can't build for — where it now refuses immediately instead of tearing down first.
- Generic; no DMI, model, or hardware assumptions.

### Testing

```
KERNEL_RELEASE=7.1.7-200.fc44.x86_64   -> allowed
KERNEL_RELEASE=6.19.10-300.fc44.x86_64 -> [kait2en] error: the kernel headers for
  6.19.10-300.fc44.x86_64 are missing. Install kernel-devel-…, or boot the kernel
  you want to build for. Nothing was changed.

bash tests/installer/static-check.sh   -> Installer static checks passed.
```
