### PR TITLE
docs: configure kait2en.org custom domain

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,3 +40,4 @@ jobs:
           publish_branch: gh-pages
           publish_dir: ./site
           force_orphan: true
+          cname: kait2en.org

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: KAIT2EN Fedora
-site_url: https://kait2en.github.io/
+site_url: https://kait2en.org/
 repo_url: https://github.com/kaiT2en/KaiT2en-Fedora
 repo_name: kaiT2en/KAIT2EN-Fedora
 docs_dir: docs


### PR DESCRIPTION
## Summary

- use `https://kait2en.org/` as the MkDocs site URL
- preserve the custom-domain `CNAME` file on every documentation deployment

## Verification

- `mkdocs build --strict`