### PR TITLE
site: canonicalise the homepage to the bare root

### DIFF
--- a/website/build.py
+++ b/website/build.py
@@ -519,10 +519,15 @@ def build(output: Path, site_url: str | None = None, noindex: bool = False) -> N
         "noindex": noindex,
     }
 
+    base_url = config["site"]["url"].rstrip("/")
+
     def write(name: str, template: str, **context: Any) -> None:
         depth = name.count("/")
+        # The homepage is canonically the bare root, which is what the sitemap
+        # lists and what inbound links point at.
+        canonical = f"{base_url}/{'' if name == 'index.html' else name}"
         page = env.get_template(template).render(
-            base="../" * depth, page_url=name, **shared, **context
+            base="../" * depth, page_url=name, canonical=canonical, **shared, **context
         )
         target = output / name
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -14,7 +14,7 @@
     <meta property="og:type" content="{% block og_type %}website{% endblock %}">
     <meta property="og:title" content="{{ self.title() }}">
     <meta property="og:description" content="{{ self.description() }}">
-    <meta property="og:url" content="{{ site.url }}/{{ page_url }}">
+    <meta property="og:url" content="{{ canonical }}">
     <meta property="og:image" content="{{ site.url }}/img/og-image.png">
     <meta property="og:site_name" content="{{ site.name }}">
 
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="{{ self.description() }}">
     <meta name="twitter:image" content="{{ site.url }}/img/og-image.png">
 
-    <link rel="canonical" href="{{ site.url }}/{{ page_url }}">
+    <link rel="canonical" href="{{ canonical }}">
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} blog" href="{{ base }}feed.xml">
 
     <!-- Favicon -->


### PR DESCRIPTION
The sitemap lists https://kait2en.org/ while the page claimed https://kait2en.org/index.html as its canonical, so search engines would have indexed the second and consolidated inbound links onto it.