### PR TITLE
site: add a GitHub link to the desktop navbar

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -203,7 +203,8 @@ a:hover {
     opacity: 1;
 }
 
-.nav-discord {
+.nav-discord,
+.nav-github {
     display: flex;
     align-items: center;
     gap: 6px;
@@ -215,7 +216,12 @@ a:hover {
     color: #5865f2 !important;
 }
 
-.nav-discord svg {
+.nav-github:hover {
+    color: var(--text-primary) !important;
+}
+
+.nav-discord svg,
+.nav-github svg {
     fill: currentColor;
 }
 

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -54,6 +54,10 @@
                 {% for item in nav %}
                 <a href="{{ base }}{{ item.href }}"{% if item.href == page_url %} class="active"{% endif %}>{{ item.label }}</a>
                 {% endfor %}
+                <a href="{{ links.repo }}" target="_blank" rel="noopener" class="nav-github">
+                    {{ icon.github(16) }}
+                    GitHub
+                </a>
                 <a href="{{ links.discord }}" target="_blank" rel="noopener" class="nav-discord">
                     {{ icon.discord(16) }}
                     Discord


### PR DESCRIPTION
The burger menu already listed GitHub, Discord and Matrix; the desktop navbar only had Discord. GitHub goes first so both menus read in the same order.