### PR TITLE
installer: load uinput before applying the react-drm udev rule

### DIFF
--- a/scripts/fedora/install-apps.sh
+++ b/scripts/fedora/install-apps.sh
@@ -16,8 +16,8 @@ require_root
 require_repo_root
 require_fedora
 require_command \
-	awk chown cut dnf env getent grep id install mktemp modinfo npm rm rpm \
-	sleep sudo systemctl tar tr udevadm usermod
+	awk chown cut dnf env getent grep id install mktemp modinfo modprobe npm \
+	rm rpm sleep stat sudo systemctl tar tr udevadm usermod
 if [[ "$install_mode" == all ]]; then
 	require_command cargo make
 fi
@@ -138,6 +138,7 @@ install_react_drm() {
 	local missing_groups=()
 	local service_dir service_file temporary_file workdir_q start_q detach_q
 	local desktop extension_uuid extension_src extension_dst
+	local uinput_conf uinput_group
 	if ! has_t2_touchbar_model; then
 		return
 	fi
@@ -244,9 +245,27 @@ install_react_drm() {
 	info "installing react-drm udev rules"
 	install -d -o root -g root -m 0755 /etc/udev/rules.d
 	install -o root -g root -m 0644 "$src/system/99-react-drm.rules" /etc/udev/rules.d/99-react-drm.rules
+
+	# Until the module is loaded, /dev/uinput is a kmod static node: root owned,
+	# mode 0600, and with no sysfs device for udev to match. The trigger below
+	# would then apply the rule to nothing, react-drm could not open the device,
+	# and systemd would restart it every two seconds.
+	info "loading the uinput module for react-drm"
+	uinput_conf="$(mktemp)"
+	printf 'uinput\n' >"$uinput_conf"
+	install -d -o root -g root -m 0755 /etc/modules-load.d
+	install -o root -g root -m 0644 "$uinput_conf" /etc/modules-load.d/kait2en-uinput.conf
+	rm -f "$uinput_conf"
+	modprobe uinput || fail "unable to load the uinput module, which react-drm requires"
+
 	udevadm control --reload
 	udevadm trigger --action=add --subsystem-match=usb --subsystem-match=backlight
 	udevadm trigger --action=add --subsystem-match=misc --sysname-match=uinput
+	udevadm settle
+
+	uinput_group="$(stat -c %G /dev/uinput 2>/dev/null || printf 'missing')"
+	[[ "$uinput_group" == input ]] ||
+		fail "/dev/uinput belongs to group $uinput_group, not input, so react-drm cannot open it. Check /etc/udev/rules.d/99-react-drm.rules."
 
 	info "copying react-drm source to $dst"
 	rm -rf "$dst"

--- a/tests/installer/static-check.sh
+++ b/tests/installer/static-check.sh
@@ -82,6 +82,14 @@ grep -Fq 'dracut --force --force-drivers' \
 # without headers has to be refused before anything is removed.
 grep -Fq 'require_kernel_headers' scripts/fedora/install-dkms-modules.sh
 grep -Fq 'require_kernel_headers()' scripts/fedora/lib.sh
+
+# /dev/uinput is a kmod static node until the module is loaded, so the udev
+# trigger matches nothing and the input group never gets access. react-drm then
+# cannot open it and systemd restarts it every two seconds.
+grep -Fq 'modprobe uinput' scripts/fedora/install-apps.sh
+grep -Fq '/etc/modules-load.d/kait2en-uinput.conf' scripts/fedora/install-apps.sh
+grep -Fq 'stat -c %G /dev/uinput' scripts/fedora/install-apps.sh
+
 grep -Fq '"etc", "xdg", "autostart"' \
 	packaging/installer/anaconda-addon/com_kait2en_input/service/installation.py
 ! grep -InE 'find_regular_user|home\.lstrip|os\.chown' \


### PR DESCRIPTION
### What happens

On my MacBookPro16,1 the Touch Bar was blinking non-stop and the laptop ran hot. It turned out react-drm was crashing and restarting every 2 seconds because it cannot open `/dev/uinput`.

The reason is that `/dev/uinput` isn't a real device until the `uinput` module is loaded. Until then it's a placeholder node owned by root with mode 0600, and there is nothing in sysfs for udev to match on. So the `udevadm trigger` for uinput in `install-apps.sh` matches nothing, and the `GROUP="input"` line in `99-react-drm.rules` never gets applied.

Every time react-drm starts it attaches the Touch Bar, and every time it dies it lets go again, so the USB configuration keeps flipping back and forth. That is the blinking, and it also keeps the T2 USB bus busy the whole time. 

The Touch Bar had never worked since I installed.

### The fix

Load the module before triggering udev, add it to `modules-load.d` so it comes back after a reboot, and then check that `/dev/uinput` really did end up in the `input` group. At the moment the installer reports success even when none of this worked.