### PR TITLE
installer: force the input modules into every initramfs

### DIFF
--- a/scripts/fedora/rebuild-initramfs.sh
+++ b/scripts/fedora/rebuild-initramfs.sh
@@ -5,11 +5,24 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/lib.sh"
 require_root
 require_repo_root
 require_fedora
-require_command dracut
+require_command dracut install lsinitrd
 
+INPUT_MODULES=(t2bce_dma t2bce_core t2bce_vhci t2hid)
+DRACUT_CONF="/etc/dracut.conf.d/90-kait2en-input.conf"
 KVER="$(kernel_release)"
+INITRAMFS="/boot/initramfs-$KVER.img"
+
+install -d -m 0755 /etc/dracut.conf.d
+printf '# Managed by scripts/fedora/rebuild-initramfs.sh\nforce_drivers+=" %s "\n' \
+	"${INPUT_MODULES[*]}" >"$DRACUT_CONF"
 
 info "rebuilding initramfs for $KVER"
-dracut --force "/boot/initramfs-$KVER.img" "$KVER"
+dracut --force "$INITRAMFS" "$KVER"
+
+listing="$(lsinitrd "$INITRAMFS")"
+for module in "${INPUT_MODULES[@]}"; do
+	[[ "$listing" == *"/$module.ko"* ]] ||
+		fail "the rebuilt initramfs for $KVER is missing $module"
+done
 
 info "initramfs rebuilt"

--- a/scripts/tests/static-check.sh
+++ b/scripts/tests/static-check.sh
@@ -22,6 +22,7 @@ shell_files=(
 	scripts/fedora/build-installer.sh
 	scripts/fedora/install-dkms-modules.sh
 	scripts/fedora/lib.sh
+	scripts/fedora/rebuild-initramfs.sh
 	scripts/macos/download-fedora-iso.sh
 	scripts/macos/prepare-fedora-installer.sh
 	scripts/tests/edition-catalog.sh
@@ -77,6 +78,8 @@ grep -Fq '"$transition_source" "$target_kernel" "$work/rpm"' \
 grep -Fq 'dracut --force --force-drivers' \
 	packaging/installer/runtime/kait2en-prepare
 ! grep -Fq -- '--add-drivers' packaging/installer/runtime/kait2en-prepare
+
+grep -Fq 'force_drivers' scripts/fedora/rebuild-initramfs.sh
 
 # DKMS drops every kernel's build before rebuilding any of them, so a kernel
 # without headers has to be refused before anything is removed.

--- a/website/docs/reference/installed-files.md
+++ b/website/docs/reference/installed-files.md
@@ -146,6 +146,7 @@ audio behavior and diagnostics.
 | `/etc/systemd/system/kait2en-t2-ncm-down.service` | Starts when `t2_ncm` appears |
 | `/usr/local/libexec/kait2en/kait2en-t2-ncm-down.sh` | Keeps the internal debug interface down |
 | `/usr/share/plymouth/themes/kait2en/` | Fedora's spinner theme with the KAIT2EN watermark |
+| `/etc/dracut.conf.d/90-kait2en-input.conf` | Forces the T2 keyboard modules into every initramfs, including the ones Dracut builds during a kernel update |
 | `/boot/initramfs-<running-kernel>.img` | Rebuilt by Dracut after modules and ACPI handling are complete |
 
 `kait2en-suspend.service` is enabled on every installation. Before suspend, it


### PR DESCRIPTION
After installing, my keyboard didn't work at the LUKS prompt on kernel 7.1.7 and I couldn't unlock the disk. Had to boot the old kernel to get in.

The initramfs had none of the T2 input modules — the only HID thing in there was the generic multitouch driver:

```
$ lsinitrd /boot/initramfs-7.1.7-200.fc44.x86_64.img | grep -Ei 't2bce|t2hid|t2magicmouse|hid-multitouch'
usr/lib/modules/7.1.7-200.fc44.x86_64/kernel/drivers/hid/hid-multitouch.ko.xz
```

The two earlier installer stages both name the modules and check they made it in. rebuild-initramfs.sh just does `dracut --force` and checks nothing, so it relies on host-only autodetection.
