### PR TITLE
 Fixes the Touch Bar keyboard-illumination buttons, which did nothing on GNOME Wayland.  

### DIFF
--- a/apps/react-drm/linux-touchbar-control-center/layers/mediaScreen.tsx
+++ b/apps/react-drm/linux-touchbar-control-center/layers/mediaScreen.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-icons/md';
 import { BackButton } from '../components/BackButton';
 import { keys } from '../services/keyInjector';
+import { stepKeyboardBacklight } from '../services/keyboardBacklight';
 
 const isBuilt = __dirname.includes(path.sep + 'dist' + path.sep);
 
@@ -24,6 +25,12 @@ const KBD_ILLUM_UP_ICON = isBuilt
   : path.join(__dirname, '..', 'assets', 'kbd_illum_up.svg');
 
 // ── Actions ────────────────────────────────────────────────────────────────────
+
+// macOS steps the keyboard backlight through ~8 levels; 1/8 of max per press.
+// We drive the t2hid LED directly via brightnessctl instead of injecting
+// KEY_KBDILLUMDOWN/UP: no compositor/daemon on a GNOME Wayland session listens
+// for those keycodes, so the buttons were dead weight there.
+const KBD_ILLUM_STEP = 0.125;
 
 type Action =
   | 'Macro1'
@@ -42,8 +49,8 @@ function run(action: Action) {
     case 'BrightnessUp':     return keys.pressKey(KEY.BRIGHTNESSUP);
     case 'MicMute':          return keys.pressKey(KEY.MICMUTE);
     case 'Search':           return keys.pressKey(KEY.SEARCH);
-    case 'IllumDown':        return keys.pressKey(KEY.KBDILLUMDOWN);
-    case 'IllumUp':          return keys.pressKey(KEY.KBDILLUMUP);
+    case 'IllumDown':        stepKeyboardBacklight(-KBD_ILLUM_STEP); return;
+    case 'IllumUp':          stepKeyboardBacklight( KBD_ILLUM_STEP); return;
     case 'PreviousSong':     return keys.pressKey(KEY.PREVIOUSSONG);
     case 'PlayPause':        return keys.pressKey(KEY.PLAYPAUSE);
     case 'NextSong':         return keys.pressKey(KEY.NEXTSONG);

--- a/apps/react-drm/linux-touchbar-control-center/services/keyboardBacklight.ts
+++ b/apps/react-drm/linux-touchbar-control-center/services/keyboardBacklight.ts
@@ -1,0 +1,51 @@
+import { execFile, execFileSync } from 'child_process';
+import fs from 'fs';
+
+// The T2 keyboard backlight is exposed by the t2hid driver as an LED whose
+// name ends in "kbd_backlight" (e.g. ":white:kbd_backlight") under
+// /sys/class/leds. Auto-detect it instead of hardcoding, so the control keeps
+// working if the driver renames the LED or a machine exposes a differently
+// named device.
+function findKbdBacklightDevice(): string | null {
+  try {
+    return fs.readdirSync('/sys/class/leds').find(n => n.includes('kbd_backlight')) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function brightnessctl(args: string[]): string | null {
+  try {
+    return execFileSync('brightnessctl', args, { encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Current keyboard backlight as a fraction of max (0..1), 0.5 if unknown. */
+export function getKeyboardBacklightPercent(): number {
+  const device = findKbdBacklightDevice();
+  if (!device) return 0.5;
+  const cur = brightnessctl(['--device', device, 'get']);
+  const max = brightnessctl(['--device', device, 'max']);
+  if (cur === null || max === null) return 0.5;
+  const curN = parseInt(cur, 10);
+  const maxN = parseInt(max, 10);
+  return maxN > 0 ? Math.min(1, Math.max(0, curN / maxN)) : 0.5;
+}
+
+/** Set the keyboard backlight to a fraction of max (0..1). */
+export function setKeyboardBacklightPercent(pct: number): void {
+  const device = findKbdBacklightDevice();
+  if (!device) return;
+  const clamped = Math.max(0, Math.min(100, Math.round(pct * 100)));
+  // brightnessctl talks to systemd-logind (SetBrightness) when the sysfs LED
+  // is not directly writable by the session user, so this works without root
+  // and without any desktop daemon (gsd/upower) being involved.
+  execFile('brightnessctl', ['--device', device, 'set', `${clamped}%`], () => {});
+}
+
+/** Step the keyboard backlight by a delta given as a fraction of max. */
+export function stepKeyboardBacklight(deltaPct: number): void {
+  setKeyboardBacklightPercent(getKeyboardBacklightPercent() + deltaPct);
+}


### PR DESCRIPTION
## Summary

Fixes the Touch Bar keyboard-illumination (+/−) buttons, which did nothing on GNOME/Wayland.

The buttons injected `KEY_KBDILLUMDOWN/UP` keycodes via uinput, expecting the desktop power stack to react. 
The chain *xkb keysym → gsd-media-keys → gsd-power → upower legacy `KbdBacklight` → LED* is fragile:

1. **upower** exports the legacy flat-path interface (`/org/freedesktop/UPower/KbdBacklight`) only if a **one-shot scan** at daemon start finds the LED.
2. **gsd-power** creates its upower proxy **once at startup** and never retries.

On T2 hardware the keyboard LED appears ~1s after upower starts, so the scan routinely misses it, directly observed at boot:

```text
03:49:47  upowerd: cannot find a keyboard backlight
03:49:48  t2hid: restoring keyboard backlight brightness 0
03:49:49  upowerd: Exported Keyboard backlight with path .../owhiteokbd_backlight
```

Only the per-device path gets exported (it's event-driven); the legacy flat path, the one gsd-power uses, never appears, and the buttons are dead for the whole session. It's a per-boot coin flip: the buttons work on some boots and silently die on others.

## Change

The buttons now drive the `t2hid` LED directly via `brightnessctl`, which routes the write through **systemd-logind's `SetBrightness`**, no root and no dependency on the desktop power stack, deterministic on every boot. Each press steps the backlight by 1/8 of max, mirroring macOS's ~8 levels.

| File | Change |
| --- | --- |
| `services/keyboardBacklight.ts` *(new)* | Auto-detects the `*kbd_backlight` LED; wraps `brightnessctl` get/set/step |
| `layers/mediaScreen.tsx` | `IllumUp`/`IllumDown` step the LED instead of injecting dead keycodes |

## Testing

- Verified on MacBookPro15,1 (Fedora 44, GNOME 50, Wayland)
- Both buttons adjust the backlight correctly, regardless of upower/gsd state
- `brightnessctl` write path confirmed working end-to-end (LED → `t2hid` → keyboard)

## Related note

The same fragile chain also makes the GNOME Settings keyboard-brightness slider disappear on boots where the race is lost (restarting upower + gsd-power restores it). That's an upstream upower/gnome-settings-daemon issue (one-shot flat-path export vs. `EnumerateKbdBacklights`)..