### PR TITLE
modules: fix builds against Linux 7.2

### DIFF
--- a/modules/t2bce_audio/audio.c
+++ b/modules/t2bce_audio/audio.c
@@ -442,8 +442,8 @@ static void t2audio_init_dev(struct t2audio_device *a, t2audio_device_id_t dev_i
     INIT_LIST_HEAD(&sdev->list);
     sdev->dev_id = dev_id;
     sdev->buf_id = T2AUDIO_BUFFER_ID_NONE;
-    strncpy(sdev->uid, uid, uid_len);
-    sdev->uid[uid_len + 1] = '\0';
+    memcpy(sdev->uid, uid, uid_len);
+    sdev->uid[uid_len] = '\0';
 
     if (t2audio_cmd_get_primitive_property(a, dev_id, dev_id,
             T2AUDIO_PROP(T2AUDIO_PROP_SCOPE_INPUT, T2AUDIO_PROP_LATENCY, 0), NULL, 0, &sdev->in_latency, sizeof(u32)))

--- a/modules/t2bdrm/t2bdrm.c
+++ b/modules/t2bdrm/t2bdrm.c
@@ -17,6 +17,7 @@
 #include <linux/types.h>
 #include <linux/unaligned.h>
 #include <linux/usb.h>
+#include <linux/version.h>
 
 #include <drm/drm_atomic.h>
 #include <drm/drm_atomic_helper.h>
@@ -33,6 +34,10 @@
 #include <drm/drm_plane.h>
 #include <drm/drm_print.h>
 #include <drm/drm_probe_helper.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 2, 0)
+#define drm_atomic_commit drm_atomic_state
+#endif
 
 #define APPLETBDRM_PIXEL_FORMAT		cpu_to_le32(0x52474241) /* RGBA, the actual format is BGR888 */
 #define APPLETBDRM_BITS_PER_PIXEL	24
@@ -316,7 +321,7 @@ static const u32 appletbdrm_primary_plane_formats[] = {
 };
 
 static int appletbdrm_primary_plane_helper_atomic_check(struct drm_plane *plane,
-						   struct drm_atomic_state *state)
+						   struct drm_atomic_commit *state)
 {
 	struct drm_plane_state *new_plane_state = drm_atomic_get_new_plane_state(state, plane);
 	struct drm_plane_state *old_plane_state = drm_atomic_get_old_plane_state(state, plane);
@@ -468,7 +473,7 @@ end_fb_cpu_access:
 }
 
 static void appletbdrm_primary_plane_helper_atomic_update(struct drm_plane *plane,
-						     struct drm_atomic_state *old_state)
+						     struct drm_atomic_commit *old_state)
 {
 	struct appletbdrm_device *adev = drm_to_adev(plane->dev);
 	struct drm_device *drm = plane->dev;
@@ -485,7 +490,7 @@ static void appletbdrm_primary_plane_helper_atomic_update(struct drm_plane *plan
 }
 
 static void appletbdrm_primary_plane_helper_atomic_disable(struct drm_plane *plane,
-							   struct drm_atomic_state *state)
+							   struct drm_atomic_commit *state)
 {
 	struct drm_device *dev = plane->dev;
 	struct appletbdrm_device *adev = drm_to_adev(dev);


### PR DESCRIPTION
fixes for t2bdrm and t2bce_audio to make it compatible with Linux 7.2.
The rest of the modules work fine. 

In Linux 7.2 drm_atomic_state was renamed to drm_atomic_commit and they removed strncpy(), so t2bdrm and t2bce_audio no longer build. 

This uses the new names and swaps `strncpy()` for `memcpy()` plus a terminator, which also fixes an old off-by-one that wrote one byte past the end of `sdev->uid`. 

Older kernels still work: the rename is aliased back behind a version check.