### PR TITLE
react-drm: long-press-and-drag sliders from upstream

### DIFF
--- a/apps/react-drm/linux-touchbar-control-center/components/BackButton.tsx
+++ b/apps/react-drm/linux-touchbar-control-center/components/BackButton.tsx
@@ -21,7 +21,7 @@ export function BackButton({
       style={{ alignItems: 'center', justifyContent: 'center' }}
       onClick={() => go(to, switchOptions ?? animation)}
     >
-      <MdCancel style={{ width: 40, height: 40 }} fill="#cccccc" stroke="none" />
+      <MdCancel style={{ width: 32, height: 32 }} fill="#cccccc" stroke="none" />
     </Button>
   );
 }

--- a/apps/react-drm/linux-touchbar-control-center/components/SliderTrack.tsx
+++ b/apps/react-drm/linux-touchbar-control-center/components/SliderTrack.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Box } from 'react-drm';
+
+// Real macOS Touch Bar OSD slider: a thin line with a large gray knob that
+// carries the icon and rides on top of it at all times — not a Control
+// Center panel pill. Filled (left of knob) is a thicker bright line; empty
+// (right of knob) is a thin translucent one.
+const KNOB_D        = 32;
+const LINE_FILLED_H = 4;
+const LINE_EMPTY_H  = 2;
+
+/** Fully-rounded (pill/circle) radius for a box of height `h`. */
+const pillRadius = (h: number) => h / 2;
+
+export function SliderTrack({ fill, icon, width }: {
+  fill: number;
+  icon: React.ReactNode;
+  width: number;
+}) {
+  // Rounded to whole pixels — the native renderer builds each rounded-rect
+  // path from these coordinates directly, and fractional edges here can get
+  // clipped by a hair on whichever side the fraction lands, depending on the
+  // current fill value. Integer pixels keep every edge landing consistently.
+  const knobX      = Math.round(Math.max(0, Math.min(width - KNOB_D, fill * width - KNOB_D / 2)));
+  const knobCenter = knobX + KNOB_D / 2;
+  const filledW    = Math.max(0, Math.min(width, knobCenter));
+  const emptyX     = Math.min(width, knobCenter);
+  const emptyW     = Math.max(0, width - emptyX);
+
+  return (
+    <Box style={{ width, height: KNOB_D }}>
+      {filledW > 0 && (
+        <Box
+          style={{
+            position: 'absolute', left: 0, top: (KNOB_D - LINE_FILLED_H) / 2,
+            width: filledW, height: LINE_FILLED_H, borderRadius: pillRadius(LINE_FILLED_H),
+            backgroundColor: '#f5f5f7',
+          }}
+        />
+      )}
+      {emptyW > 0 && (
+        <Box
+          style={{
+            position: 'absolute', left: emptyX, top: (KNOB_D - LINE_EMPTY_H) / 2,
+            width: emptyW, height: LINE_EMPTY_H, borderRadius: pillRadius(LINE_EMPTY_H),
+            backgroundColor: 'rgba(255,255,255,0.22)',
+          }}
+        />
+      )}
+      <Box
+        style={{
+          position: 'absolute', left: knobX, top: 0,
+          width: KNOB_D, height: KNOB_D, borderRadius: pillRadius(KNOB_D),
+          backgroundColor: 'rgba(70,70,74,0.92)',
+          alignItems: 'center', justifyContent: 'center',
+          // shadowColor: 'rgba(0,0,0,0.5)', shadowOffsetY: 1, shadowRadius: 4, shadowOpacity: 1,
+        }}
+      >
+        {icon}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/react-drm/linux-touchbar-control-center/layers/audioSlider.tsx
+++ b/apps/react-drm/linux-touchbar-control-center/layers/audioSlider.tsx
@@ -1,106 +1,30 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { execFile, execFileSync, spawn } from 'child_process';
+import React, { useRef, useEffect } from 'react';
+import { spawn } from 'child_process';
 import { Box, Text, Button } from 'react-drm';
+import { useAtomValue } from 'jotai';
 import { MdVolumeOff, MdVolumeDown, MdVolumeUp } from 'react-icons/md';
 import { BackButton } from '@/components/BackButton';
+import { SliderTrack } from '@/components/SliderTrack';
 import { useLayers } from './index';
 import { createLogger } from 'react-drm';
+import { useVolumeControl, readVolume, TRACK_W, clampVolume } from '@/lib/hooks/useVolume';
+import { PW_ENV } from '@/lib/services/volume';
+import { audioTrackAnchorAtom, ANCHOR_TRACK_W } from '@/store/audioTrackAnchor';
 
 const log = createLogger('audioSlider');
 
-// When running as root the session socket isn't inherited — pass it explicitly.
-const PW_ENV: NodeJS.ProcessEnv = {
-  ...process.env,
-  XDG_RUNTIME_DIR:  process.env.XDG_RUNTIME_DIR  ?? '/run/user/1000',
-  PIPEWIRE_REMOTE:  process.env.PIPEWIRE_REMOTE   ?? '/run/user/1000/pipewire-0',
-};
-
-// ── Backend detection ─────────────────────────────────────────────────────────
-
-function hasWpctl(): boolean {
-  try { execFileSync('wpctl', ['--help'], { encoding: 'utf8', env: PW_ENV }); return true; }
-  catch { return false; }
-}
-
-const USE_WPCTL = hasWpctl();
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function readVolume(): number {
-  try {
-    if (USE_WPCTL) {
-      const out = execFileSync('wpctl', ['get-volume', '@DEFAULT_AUDIO_SINK@'],
-        { encoding: 'utf8', env: PW_ENV });
-      // "Volume: 0.50" or "Volume: 0.50 [MUTED]"
-      const m = out.match(/Volume:\s*([\d.]+)/);
-      return m ? Math.min(1, parseFloat(m[1])) : 0.5;
-    } else {
-      const out = execFileSync('pactl', ['get-sink-volume', '@DEFAULT_SINK@'],
-        { encoding: 'utf8' });
-      // "Volume: front-left: 65536 /  100% / ..."
-      const m = out.match(/(\d+)%/);
-      return m ? Math.min(1, parseInt(m[1]) / 100) : 0.5;
-    }
-  } catch { return 0.5; }
-}
-
-function applyVolume(pct: number, done: () => void): void {
-  if (USE_WPCTL) {
-    execFile('wpctl', ['set-volume', '@DEFAULT_AUDIO_SINK@', pct.toFixed(4)],
-      { env: PW_ENV },
-      (err) => {
-        if (err) console.error('[audioSlider] wpctl:', err.message);
-        done();
-      },
-    );
-  } else {
-    execFile('pactl', ['set-sink-volume', '@DEFAULT_SINK@', `${Math.round(pct * 100)}%`],
-      (err) => {
-        if (err) console.error('[audioSlider] pactl:', err.message);
-        done();
-      },
-    );
-  }
-}
-
 function Sep() {
   return <Box style={{ width: 1, height: 28, backgroundColor: '#1e293b' }} />;
-}
-
-// ── Track ─────────────────────────────────────────────────────────────────────
-
-const TRACK_W  = 700;
-const HANDLE_D = 14;
-
-function Track({ fill, color }: { fill: number; color: string }) {
-  const fillW  = Math.round(fill * TRACK_W);
-  const handleX = Math.max(0, Math.min(TRACK_W - HANDLE_D, fillW - HANDLE_D / 2));
-
-  return (
-    <Box style={{ width: TRACK_W, height: HANDLE_D }}>
-      {/* Dim track */}
-      <Box style={{ position: 'absolute', left: 0,     top: 6, width: TRACK_W, height: 2, backgroundColor: '#1e293b' }} />
-      {/* Filled portion */}
-      {fillW > 0 && (
-        <Box style={{ position: 'absolute', left: 0, top: 6, width: fillW, height: 2, backgroundColor: color }} />
-      )}
-      {/* Handle */}
-      <Box style={{ position: 'absolute', left: handleX, top: 0, width: HANDLE_D, height: HANDLE_D, borderRadius: HANDLE_D / 2, backgroundColor: color }}>
-        {/* <Box style={{ position: 'absolute', left: 4, top: 4, width: 6, height: 6, borderRadius: 3, backgroundColor: '#0f172a' }} /> */}
-      </Box>
-    </Box>
-  );
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function AudioSliderLayer({ width, height }: { width: number; height: number }) {
   const { go } = useLayers();
-  const [vol, setVol] = useState<number>(() => readVolume());
+  const { vol, setVolume, syncVolume } = useVolumeControl();
+  const anchor = useAtomValue(audioTrackAnchorAtom);
   const drag = useRef<{ x: number; v: number } | null>(null);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const volumeWriteBusy = useRef(false);
-  const queuedVolume = useRef<number | null>(null);
 
   function clearHideTimer() {
     if (hideTimer.current) {
@@ -113,20 +37,27 @@ export function AudioSliderLayer({ width, height }: { width: number; height: num
     clearHideTimer();
     hideTimer.current = setTimeout(() => {
       drag.current = null;
-      go('splitted', 'slide-down');
+      go('splitted', 'fade');
     }, 5000);
   }
+
+  // Reset the inactivity countdown on every volume change — covers both a
+  // drag on this layer's own track and one still being driven by the
+  // splitted layer's volume button (long-press-and-drag), which never
+  // touches this track directly so onTouchStart/onTouchEnd below never fire.
+  useEffect(() => {
+    scheduleHide();
+  }, [vol]);
 
   // Sync when volume changes externally (keyboard shortcut, another app).
   // PipeWire/PulseAudio is socket-based so chokidar can't watch it —
   // pactl subscribe is the audio equivalent of a file watcher.
   useEffect(() => {
-    scheduleHide(); // auto-close after inactivity, even if the slider is never touched
     const proc = spawn('pactl', ['subscribe'], { env: PW_ENV });
 
     proc.stdout?.on('data', (chunk: Buffer) => {
       if (chunk.toString().includes("'change' on sink") && !drag.current) {
-        setVol(readVolume());
+        syncVolume(readVolume());
       }
     });
 
@@ -138,49 +69,30 @@ export function AudioSliderLayer({ width, height }: { width: number; height: num
     };
   }, []);
 
-  function clamp(v: number) { return Math.max(0, Math.min(1, v)); }
-
-  function flushVolume() {
-    if (volumeWriteBusy.current || queuedVolume.current === null) return;
-
-    const value = queuedVolume.current;
-    queuedVolume.current = null;
-    volumeWriteBusy.current = true;
-
-    applyVolume(value, () => {
-      volumeWriteBusy.current = false;
-      flushVolume();
-    });
-  }
-
-  function update(v: number) {
-    setVol(v);
-    queuedVolume.current = v;
-    flushVolume();
-  }
+  // Anchored (long-press) drags a smaller popover track; the default
+  // centered slider stays the full TRACK_W. Sensitivity must match whichever
+  // one is actually rendered, or a direct drag on the visible track would
+  // feel decoupled from how far the finger actually needs to move.
+  const activeTrackW = anchor ? ANCHOR_TRACK_W : TRACK_W;
 
   function onMove(x: number) {
     if (!drag.current) return;
-    const nv = clamp(drag.current.v + (x - drag.current.x) / TRACK_W);
-    update(nv);
+    const nv = clampVolume(drag.current.v + (x - drag.current.x) / activeTrackW);
+    setVolume(nv);
     drag.current = { x, v: nv };
   }
 
   const VolumeIcon = vol < 0.02 ? MdVolumeOff : vol < 0.5 ? MdVolumeDown : MdVolumeUp;
-  const iconColor  = vol < 0.02 ? '#475569' : '#38bdf8';
 
-  return (
-    <Box style={{ flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 12 }}>
-      <BackButton to="splitted" animation="slide-down" />
-      <Sep />
+  const PERCENT_W = 52;
+  const PERCENT_GAP = 12;
 
-      <Box style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-        <VolumeIcon style={{ width: 28, height: 28 }} fill={iconColor} stroke="none" />
-        <Text style={{ fontSize: 13, color: '#64748b', fontFamily: 'IosevkaTerm Nerd Font' }}>VOLUME</Text>
-      </Box>
-
+  // Track + its percentage readout, grouped so the text rides along with
+  // the track when it's anchored to a touch point instead of centered.
+  const trackAndPercentage = (
+    <Box style={{ flexDirection: 'row', alignItems: 'center', gap: PERCENT_GAP }}>
       <Button
-        width={TRACK_W} height={height}
+        width={activeTrackW} height={height}
         color="transparent" activeColor="transparent"
         style={{ justifyContent: 'center', alignItems: 'center' }}
         onTouchStart={(x) => {
@@ -190,16 +102,46 @@ export function AudioSliderLayer({ width, height }: { width: number; height: num
         onTouchMove={onMove}
         onTouchEnd={() => {
           drag.current = null;
-          flushVolume();
           scheduleHide();
         }}
       >
-        <Track fill={vol} color="#38bdf8" />
+        <SliderTrack
+          fill={vol}
+          width={activeTrackW}
+          icon={<VolumeIcon style={{ width: 18, height: 18}} fill="#f5f5f7" stroke="none" />}
+        />
       </Button>
 
-      <Text style={{ width: 52, fontSize: 18, color: '#94a3b8', fontFamily: 'IosevkaTerm Nerd Font' }}>
+      <Text style={{ width: PERCENT_W, fontSize: 18, color: '#94a3b8' }}>
         {`${Math.round(vol * 100)}%`}
       </Text>
+    </Box>
+  );
+
+  return (
+    <Box style={{ flex: 1, flexDirection: 'row', alignItems: 'center' }}>
+      <BackButton to="splitted" animation="fade" />
+
+      <Box style={{ flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 12 }}>
+        {/* <Sep /> */}
+        {anchor
+          ? <Box style={{ width: activeTrackW + PERCENT_GAP + PERCENT_W, height }} />
+          : trackAndPercentage}
+      </Box>
+
+      {anchor && (
+        // Opened via long-press-and-drag: the track (and its percentage
+        // readout) render where the touch was, not centered, and at the
+        // smaller ANCHOR_TRACK_W. Positioned as a direct sibling of
+        // BackButton — not nested inside the centered inner Box above — so
+        // `left` is measured from this layer's own root origin, the same
+        // coordinate space anchor.x was captured in. See
+        // store/audioTrackAnchor.ts for why trackLeft = touchX -
+        // vol*ANCHOR_TRACK_W lands the knob exactly on the touch point.
+        <Box style={{ position: 'absolute', left: anchor.x, top: 0, height }}>
+          {trackAndPercentage}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/apps/react-drm/linux-touchbar-control-center/layers/brightnessSlider.tsx
+++ b/apps/react-drm/linux-touchbar-control-center/layers/brightnessSlider.tsx
@@ -1,72 +1,19 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { execFile, execFileSync } from 'child_process';
-import fs from 'fs';
-import { Box, Text, Button, DISPLAY_BACKLIGHT_NAMES } from 'react-drm';
+import { Box, Text, Button } from 'react-drm';
 import { MdBrightness4, MdBrightness6, MdBrightness7, MdKeyboard } from 'react-icons/md';
 import { BackButton } from '@/components/BackButton';
+import { SliderTrack } from '@/components/SliderTrack';
 import { useLayers } from './index';
+import { useDisplayBrightnessControl, readBrightness, DISPLAY_DEVICE, KEYBOARD_DEVICE } from '@/lib/hooks/useBrightness';
+import { applyBrightness } from '@/lib/services/brightness';
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-// Device names vary by hardware: the panel backlight is gmux_backlight on
-// dual-GPU Macs but intel_backlight on single-GPU ones (e.g. 2020 13" Intel),
-// and the keyboard LED is exposed as ':white:kbd_backlight'. Auto-detect instead
-// of hardcoding so the sliders work
-// across machines and don't spam "Device not found" from the poll loop.
-// Display candidate list mirrors tiny-dfr's find_display_backlight().
-function findDevice(base: string, match: (name: string) => boolean): string | null {
-  try { return fs.readdirSync(base).find(match) ?? null; } catch { return null; }
-}
-
-const DISPLAY_DEVICE  = findDevice('/sys/class/backlight', n => DISPLAY_BACKLIGHT_NAMES.some(c => n.includes(c)));
-const KEYBOARD_DEVICE = findDevice('/sys/class/leds', n => n.includes('kbd_backlight'));
 const AUTO_HIDE_MS = 5000;
-
-function readBrightness(device: string | null): number {
-  if (!device) return 0.5;
-  try {
-    const cur = parseInt(execFileSync('brightnessctl', ['--device', device, 'get'], { encoding: 'utf8' }).trim());
-    const max = parseInt(execFileSync('brightnessctl', ['--device', device, 'max'], { encoding: 'utf8' }).trim());
-    return max > 0 ? Math.min(1, cur / max) : 0.5;
-  } catch { return 0.5; }
-}
-
-function applyBrightness(device: string | null, pct: number, minimumPct: number): void {
-  if (!device) return;
-  const value = Math.max(minimumPct, Math.round(pct * 100));
-  execFile('brightnessctl', ['--device', device, 'set', `${value}%`], () => {});
-}
-
-// ── Track ─────────────────────────────────────────────────────────────────────
-
-const TRACK_W  = 700;
-const HANDLE_D = 14;
-
-function Track({ fill, color }: { fill: number; color: string }) {
-  const fillW   = Math.round(fill * TRACK_W);
-  const handleX = Math.max(0, Math.min(TRACK_W - HANDLE_D, fillW - HANDLE_D / 2));
-
-  return (
-    <Box style={{ width: TRACK_W, height: HANDLE_D }}>
-      {/* Dim track */}
-      <Box style={{ position: 'absolute', left: 0,     top: 6, width: TRACK_W, height: 2, backgroundColor: '#1e293b' }} />
-      {/* Filled portion */}
-      {fillW > 0 && (
-        <Box style={{ position: 'absolute', left: 0, top: 6, width: fillW, height: 2, backgroundColor: color }} />
-      )}
-      {/* Handle */}
-      <Box style={{ position: 'absolute', left: handleX, top: 0, width: HANDLE_D, height: HANDLE_D, borderRadius: HANDLE_D / 2, backgroundColor: color }}>
-        <Box style={{ position: 'absolute', left: 4, top: 4, width: 6, height: 6, borderRadius: 3, backgroundColor: '#0f172a' }} />
-      </Box>
-    </Box>
-  );
-}
+const TRACK_W = 700;
 
 interface BrightnessControlProps {
-  label: string;
   value: number;
-  color: string;
   icon: React.ReactNode;
+  height: number;
   dragRef: React.MutableRefObject<{ x: number; v: number } | null>;
   onChange: (value: number) => void;
   onInteractionStart: () => void;
@@ -74,10 +21,9 @@ interface BrightnessControlProps {
 }
 
 function BrightnessControl({
-  label,
   value,
-  color,
   icon,
+  height,
   dragRef,
   onChange,
   onInteractionStart,
@@ -94,14 +40,9 @@ function BrightnessControl({
 
   return (
     <Box style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-      <Box style={{ width: 92, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
-        {icon}
-        <Text style={{ fontSize: 13, color: '#64748b', fontFamily: 'IosevkaTerm Nerd Font' }}>{label}</Text>
-      </Box>
-
       <Button
         width={TRACK_W}
-        height={60}
+        height={height}
         color="transparent"
         activeColor="transparent"
         style={{ justifyContent: 'center', alignItems: 'center' }}
@@ -115,7 +56,7 @@ function BrightnessControl({
           onInteractionEnd();
         }}
       >
-        <Track fill={value} color={color} />
+        <SliderTrack fill={value} width={TRACK_W} icon={icon} />
       </Button>
 
       <Text style={{ width: 52, fontSize: 18, color: '#94a3b8', fontFamily: 'IosevkaTerm Nerd Font' }}>
@@ -129,7 +70,7 @@ function BrightnessControl({
 
 export function BrightnessSliderLayer({ width, height }: { width: number; height: number }) {
   const { go } = useLayers();
-  const [displayBrightness, setDisplayBrightness] = useState(() => readBrightness(DISPLAY_DEVICE));
+  const { brightness: displayBrightness, setBrightness: updateDisplay, syncBrightness } = useDisplayBrightnessControl();
   const [keyboardBrightness, setKeyboardBrightness] = useState(() => readBrightness(KEYBOARD_DEVICE));
   const displayDrag = useRef<{ x: number; v: number } | null>(null);
   const keyboardDrag = useRef<{ x: number; v: number } | null>(null);
@@ -147,16 +88,24 @@ export function BrightnessSliderLayer({ width, height }: { width: number; height
     hideTimer.current = setTimeout(() => {
       displayDrag.current = null;
       keyboardDrag.current = null;
-      go('splitted', 'slide-down');
+      go('splitted', 'fade');
     }, AUTO_HIDE_MS);
   }
+
+  // Reset the inactivity countdown on every display-brightness change — covers
+  // both a drag on this layer's own track and one still being driven by the
+  // splitted layer's brightness button (long-press-and-drag), which never
+  // touches this track directly so onInteractionStart/End below never fire.
+  useEffect(() => {
+    scheduleHide();
+  }, [displayBrightness]);
 
   useEffect(() => {
     scheduleHide();
     const id = setInterval(() => {
       if (!displayDrag.current) {
         const current = readBrightness(DISPLAY_DEVICE);
-        setDisplayBrightness(previous => Math.abs(previous - current) > 0.01 ? current : previous);
+        syncBrightness(previous => Math.abs(previous - current) > 0.01 ? current : previous);
       }
       if (!keyboardDrag.current) {
         const current = readBrightness(KEYBOARD_DEVICE);
@@ -168,11 +117,6 @@ export function BrightnessSliderLayer({ width, height }: { width: number; height
       clearInterval(id);
     };
   }, []);
-
-  function updateDisplay(value: number) {
-    setDisplayBrightness(value);
-    applyBrightness(DISPLAY_DEVICE, value, 1);
-  }
 
   function updateKeyboard(value: number) {
     setKeyboardBrightness(value);
@@ -187,23 +131,21 @@ export function BrightnessSliderLayer({ width, height }: { width: number; height
 
   return (
     <Box style={{ flex: 1, flexDirection: 'row', alignItems: 'center' }}>
-      <BackButton to="splitted" animation="slide-down" />
+      <BackButton to="splitted" animation="fade" />
       <Box style={{ flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 20 }}>
         <BrightnessControl
-          label="KEYS"
           value={keyboardBrightness}
-          color="#7dd3fc"
-          icon={<MdKeyboard style={{ width: 28, height: 28 }} fill="#7dd3fc" stroke="none" />}
+          icon={<MdKeyboard style={{ width: 18, height: 18 }} fill="#f5f5f7" stroke="none" />}
+          height={height}
           dragRef={keyboardDrag}
           onChange={updateKeyboard}
           onInteractionStart={clearHideTimer}
           onInteractionEnd={scheduleHide}
         />
         <BrightnessControl
-          label="DISPLAY"
           value={displayBrightness}
-          color="#fbbf24"
-          icon={<DisplayIcon style={{ width: 28, height: 28 }} fill="#fbbf24" stroke="none" />}
+          icon={<DisplayIcon style={{ width: 18, height: 18 }} fill="#f5f5f7" stroke="none" />}
+          height={height}
           dragRef={displayDrag}
           onChange={updateDisplay}
           onInteractionStart={clearHideTimer}

--- a/apps/react-drm/linux-touchbar-control-center/layers/splittedLayer.tsx
+++ b/apps/react-drm/linux-touchbar-control-center/layers/splittedLayer.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { Box, Button, KEY, animated, useSpringValue } from 'react-drm';
-import { useAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { FaChevronLeft, FaLinux } from 'react-icons/fa6';
 import { MdPlayArrow, MdVolumeUp, MdWbSunny, MdSearch, MdMusicNote } from 'react-icons/md';
 import { LayerHost, useLayers } from '.';
@@ -8,6 +8,9 @@ import type { Layer, LayerHostHandle } from '.';
 import { useActiveWindow } from '@/lib/hooks/useActiveWindow';
 import { useMediaPlayers } from '@/lib/hooks/useMediaPlayers';
 import { mediaMprisListPinnedAtom } from '@/store/mediaMprisList';
+import { useVolumeControl, readVolume, clampVolume } from '@/lib/hooks/useVolume';
+import { useDisplayBrightnessControl, readBrightness, DISPLAY_DEVICE, TRACK_W as BRIGHTNESS_TRACK_W, clamp01 } from '@/lib/hooks/useBrightness';
+import { audioTrackAnchorAtom, ANCHOR_TRACK_W } from '@/store/audioTrackAnchor';
 import { ActiveWindowPanel } from './leftsideLayers/ActiveWindowPanel';
 import { BrowserPanel } from './leftsideLayers/BrowserPanel';
 import { KonsolePanel } from './leftsideLayers/KonsolePanel';
@@ -75,6 +78,10 @@ interface RightBtn {
   color: string;
   activeColor: string;
   onClick: () => void;
+  onLongPress?: () => void;
+  onTouchStart?: (x: number, y: number) => void;
+  onTouchMove?: (x: number, y: number) => void;
+  onTouchEnd?: (x: number, y: number) => void;
 }
 
 const BASE_BTNS: Omit<RightBtn, 'onClick'>[] = [
@@ -126,17 +133,76 @@ export function SplittedLayer({ width, height }: { width: number; height: number
   const { show: showMedia, loading: mediaLoading, players } = useMediaPlayers();
   const [isMediaMprisListPinned, setIsMediaMprisListPinned] = useAtom(mediaMprisListPinnedAtom);
   const mediaPlaying = useMemo(() => players.some(p => p.state.status === 'Playing'), [players]);
+  const { setVolume, syncVolume } = useVolumeControl();
+  const { setBrightness } = useDisplayBrightnessControl();
+  const setAudioTrackAnchor = useSetAtom(audioTrackAnchorAtom);
+  // Long-press-and-drag on the volume/brightness buttons: the touch never
+  // leaves the button's registered gesture (layer swaps don't retarget an
+  // in-progress touch), so the whole hold-then-slide-left/right gesture is
+  // driven from here even after the corresponding slider layer is on screen.
+  const volDragRef = useRef<{ x: number; v: number } | null>(null);
+  const volTouchXRef = useRef(0);
+  const brightDragRef = useRef<{ x: number; v: number } | null>(null);
+  const brightTouchXRef = useRef(0);
   const mediaBtns: RightBtn[] = useMemo(() => {
     // Dispatch each button's action by its key, not its position, so reordering
     // BASE_BTNS can't silently wire a button to the wrong action.
     const actions: Record<string, () => void> = {
       back:       () => go('media', 'slide-left'),
       linux:      () => go('systembar', 'slide-up'),
-      volume:     () => go('audio-slider', 'slide-up'),
-      brightness: () => go('brightness-slider', 'slide-up'),
+      volume:     () => { setAudioTrackAnchor(null); go('audio-slider', 'fade'); },
+      brightness: () => go('brightness-slider', 'fade'),
       playpause:  () => go('dock', 'slide-up'),
     };
     const base: RightBtn[] = BASE_BTNS.map(b => ({ ...b, onClick: actions[b.key] ?? (() => {}) }));
+    const volumeBtn = base.find(b => b.key === 'volume');
+    if (volumeBtn) {
+      volumeBtn.onTouchStart = (x) => { volTouchXRef.current = x; };
+      volumeBtn.onLongPress = () => {
+        const startVol = readVolume();
+        volDragRef.current = { x: volTouchXRef.current, v: startVol };
+        // The shared volume atom only refreshes on live pactl events while
+        // AudioSliderLayer is mounted — if volume changed externally while
+        // it wasn't (e.g. a hardware key), the atom can be stale here. Sync
+        // it to the freshly-read value so SliderTrack's fill (which drives
+        // where the knob actually renders) agrees with the anchor math below
+        // — otherwise the knob lands wherever the stale fill puts it, not on
+        // the touch point.
+        syncVolume(startVol);
+        // Anchor the track so its knob (at fill*ANCHOR_TRACK_W along the
+        // track) lands exactly on the touch point: trackLeft = touchX -
+        // vol*ANCHOR_TRACK_W. Set once — stays correct for the whole drag
+        // since the knob's own fill-driven position already absorbs the
+        // finger's movement. Sensitivity here must match ANCHOR_TRACK_W (not
+        // the default TRACK_W) since that's the width the anchored track
+        // actually renders at.
+        // 5.5 is half of the inset safe x of pixel shifting
+        setAudioTrackAnchor({ x: volTouchXRef.current -( startVol * ANCHOR_TRACK_W )-5.5});
+        go('audio-slider', 'fade');
+      };
+      volumeBtn.onTouchMove = (x) => {
+        if (!volDragRef.current) return;
+        const nv = clampVolume(volDragRef.current.v + (x - volDragRef.current.x) / ANCHOR_TRACK_W);
+        setVolume(nv);
+        volDragRef.current = { x, v: nv };
+      };
+      volumeBtn.onTouchEnd = () => { volDragRef.current = null; };
+    }
+    const brightnessBtn = base.find(b => b.key === 'brightness');
+    if (brightnessBtn) {
+      brightnessBtn.onTouchStart = (x) => { brightTouchXRef.current = x; };
+      brightnessBtn.onLongPress = () => {
+        brightDragRef.current = { x: brightTouchXRef.current, v: readBrightness(DISPLAY_DEVICE) };
+        go('brightness-slider', 'slide-up');
+      };
+      brightnessBtn.onTouchMove = (x) => {
+        if (!brightDragRef.current) return;
+        const nv = clamp01(brightDragRef.current.v + (x - brightDragRef.current.x) / BRIGHTNESS_TRACK_W);
+        setBrightness(nv);
+        brightDragRef.current = { x, v: nv };
+      };
+      brightnessBtn.onTouchEnd = () => { brightDragRef.current = null; };
+    }
     if (showMedia) {
       base.splice(1, 0, {
         key: 'media',
@@ -200,6 +266,10 @@ export function SplittedLayer({ width, height }: { width: number; height: number
                color={ btn.color}
           activeColor={ btn.activeColor}
             onClick={btn.onClick}
+            onLongPress={btn.onLongPress}
+            onTouchStart={btn.onTouchStart}
+            onTouchMove={btn.onTouchMove}
+            onTouchEnd={btn.onTouchEnd}
             style={{
               alignItems: 'center',
               justifyContent: 'center',

--- a/apps/react-drm/linux-touchbar-control-center/lib/hooks/useBrightness.ts
+++ b/apps/react-drm/linux-touchbar-control-center/lib/hooks/useBrightness.ts
@@ -1,0 +1,38 @@
+import { useAtom } from 'jotai';
+import { displayBrightnessAtom } from '@/store/brightness';
+import { applyBrightness, readBrightness, DISPLAY_DEVICE } from '@/lib/services/brightness';
+
+export { readBrightness, DISPLAY_DEVICE, KEYBOARD_DEVICE } from '@/lib/services/brightness';
+
+/** Finger-px of horizontal travel that swings brightness across its full 0–1 range. */
+export const TRACK_W = 700;
+
+export function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}
+
+/**
+ * Live display brightness plus a writer to the backlight device. Shared via
+ * `displayBrightnessAtom` so the brightness slider layer and the splitted
+ * layer's brightness button (long-press-and-drag) stay in sync regardless of
+ * which one is driving the change.
+ */
+export function useDisplayBrightnessControl() {
+  const [brightness, setAtomValue] = useAtom(displayBrightnessAtom);
+
+  function setBrightness(v: number) {
+    const clamped = clamp01(v);
+    setAtomValue(clamped);
+    applyBrightness(DISPLAY_DEVICE, clamped, 1);
+  }
+
+  // Reflects a value already applied externally (another app, a hardware
+  // key) — updates local/shared state only, no write-back to the device.
+  // Accepts an updater so callers can dead-band against the previous value
+  // (e.g. a poll loop that only wants to react to a real change).
+  function syncBrightness(v: number | ((prev: number) => number)) {
+    setAtomValue(prev => clamp01(typeof v === 'function' ? v(prev) : v));
+  }
+
+  return { brightness, setBrightness, syncBrightness };
+}

--- a/apps/react-drm/linux-touchbar-control-center/lib/hooks/useVolume.ts
+++ b/apps/react-drm/linux-touchbar-control-center/lib/hooks/useVolume.ts
@@ -1,0 +1,51 @@
+import { useRef } from 'react';
+import { useAtom } from 'jotai';
+import { volumeAtom } from '@/store/volume';
+import { applyVolume } from '@/lib/services/volume';
+
+export { readVolume } from '@/lib/services/volume';
+
+/** Finger-px of horizontal travel that swings volume across its full 0–1 range. */
+export const TRACK_W = 700;
+
+export function clampVolume(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}
+
+/**
+ * Live volume plus a debounced writer to the audio backend. Shared via
+ * `volumeAtom` so the audio slider layer and the splitted layer's volume
+ * button (long-press-and-drag) stay in sync regardless of which one is
+ * driving the change.
+ */
+export function useVolumeControl() {
+  const [vol, setVol] = useAtom(volumeAtom);
+  const busyRef = useRef(false);
+  const queuedRef = useRef<number | null>(null);
+
+  function flush() {
+    if (busyRef.current || queuedRef.current === null) return;
+    const value = queuedRef.current;
+    queuedRef.current = null;
+    busyRef.current = true;
+    applyVolume(value, () => {
+      busyRef.current = false;
+      flush();
+    });
+  }
+
+  function setVolume(v: number) {
+    const clamped = clampVolume(v);
+    setVol(clamped);
+    queuedRef.current = clamped;
+    flush();
+  }
+
+  // Reflects a value already applied externally (keyboard shortcut, another
+  // app) — updates local/shared state only, no write-back to the backend.
+  function syncVolume(v: number) {
+    setVol(clampVolume(v));
+  }
+
+  return { vol, setVolume, syncVolume };
+}

--- a/apps/react-drm/linux-touchbar-control-center/lib/services/brightness.ts
+++ b/apps/react-drm/linux-touchbar-control-center/lib/services/brightness.ts
@@ -1,0 +1,31 @@
+import { execFile, execFileSync } from 'child_process';
+import fs from 'fs';
+import { DISPLAY_BACKLIGHT_NAMES } from 'react-drm';
+
+// Device names vary by hardware: the panel backlight is gmux_backlight on
+// dual-GPU Macs but intel_backlight on single-GPU ones (e.g. 2020 13" Intel),
+// and the keyboard LED is exposed as ':white:kbd_backlight'. Auto-detect instead
+// of hardcoding so the sliders work across machines and don't spam "Device not
+// found" from the poll loop. Display candidate list mirrors tiny-dfr's
+// find_display_backlight().
+function findDevice(base: string, match: (name: string) => boolean): string | null {
+  try { return fs.readdirSync(base).find(match) ?? null; } catch { return null; }
+}
+
+export const DISPLAY_DEVICE  = findDevice('/sys/class/backlight', n => DISPLAY_BACKLIGHT_NAMES.some(c => n.includes(c)));
+export const KEYBOARD_DEVICE = findDevice('/sys/class/leds', n => n.includes('kbd_backlight'));
+
+export function readBrightness(device: string | null): number {
+  if (!device) return 0.5;
+  try {
+    const cur = parseInt(execFileSync('brightnessctl', ['--device', device, 'get'], { encoding: 'utf8' }).trim());
+    const max = parseInt(execFileSync('brightnessctl', ['--device', device, 'max'], { encoding: 'utf8' }).trim());
+    return max > 0 ? Math.min(1, cur / max) : 0.5;
+  } catch { return 0.5; }
+}
+
+export function applyBrightness(device: string | null, pct: number, minimumPct: number): void {
+  if (!device) return;
+  const value = Math.max(minimumPct, Math.round(pct * 100));
+  execFile('brightnessctl', ['--device', device, 'set', `${value}%`], () => {});
+}

--- a/apps/react-drm/linux-touchbar-control-center/lib/services/volume.ts
+++ b/apps/react-drm/linux-touchbar-control-center/lib/services/volume.ts
@@ -1,0 +1,52 @@
+import { execFile, execFileSync } from 'child_process';
+
+// When running as root the session socket isn't inherited — pass it explicitly.
+export const PW_ENV: NodeJS.ProcessEnv = {
+  ...process.env,
+  XDG_RUNTIME_DIR: process.env.XDG_RUNTIME_DIR ?? '/run/user/1000',
+  PIPEWIRE_REMOTE: process.env.PIPEWIRE_REMOTE ?? '/run/user/1000/pipewire-0',
+};
+
+function hasWpctl(): boolean {
+  try { execFileSync('wpctl', ['--help'], { encoding: 'utf8', env: PW_ENV }); return true; }
+  catch { return false; }
+}
+
+const USE_WPCTL = hasWpctl();
+
+export function readVolume(): number {
+  try {
+    if (USE_WPCTL) {
+      const out = execFileSync('wpctl', ['get-volume', '@DEFAULT_AUDIO_SINK@'],
+        { encoding: 'utf8', env: PW_ENV });
+      // "Volume: 0.50" or "Volume: 0.50 [MUTED]"
+      const m = out.match(/Volume:\s*([\d.]+)/);
+      return m ? Math.min(1, parseFloat(m[1])) : 0.5;
+    } else {
+      const out = execFileSync('pactl', ['get-sink-volume', '@DEFAULT_SINK@'],
+        { encoding: 'utf8' });
+      // "Volume: front-left: 65536 /  100% / ..."
+      const m = out.match(/(\d+)%/);
+      return m ? Math.min(1, parseInt(m[1]) / 100) : 0.5;
+    }
+  } catch { return 0.5; }
+}
+
+export function applyVolume(pct: number, done: () => void): void {
+  if (USE_WPCTL) {
+    execFile('wpctl', ['set-volume', '@DEFAULT_AUDIO_SINK@', pct.toFixed(4)],
+      { env: PW_ENV },
+      (err) => {
+        if (err) console.error('[volume] wpctl:', err.message);
+        done();
+      },
+    );
+  } else {
+    execFile('pactl', ['set-sink-volume', '@DEFAULT_SINK@', `${Math.round(pct * 100)}%`],
+      (err) => {
+        if (err) console.error('[volume] pactl:', err.message);
+        done();
+      },
+    );
+  }
+}

--- a/apps/react-drm/linux-touchbar-control-center/store/audioTrackAnchor.ts
+++ b/apps/react-drm/linux-touchbar-control-center/store/audioTrackAnchor.ts
@@ -1,0 +1,29 @@
+import { atom } from 'jotai';
+
+/**
+ * Track width for the anchored (long-press-and-drag) popover — deliberately
+ * smaller than the default centered slider's TRACK_W, since this one floats
+ * near wherever the finger pressed rather than spanning the layer. Shared by
+ * splittedLayer.tsx's drag math and audioSlider.tsx's rendering + its own
+ * direct-touch drag, so the knob position stays consistent regardless of
+ * which one is currently driving the touch.
+ */
+export const ANCHOR_TRACK_W = 300;
+
+export interface AudioTrackAnchor {
+  /** Screen x for the track's own left edge, positioned so the track's
+   *  center lands on the touch point — trackLeft = touchX - ANCHOR_TRACK_W/2.
+   *  Fixed regardless of volume; the knob then sits wherever the current
+   *  fill places it within that centered track. */
+  x: number;
+}
+
+/**
+ * Where the audio-slider track should render, so it's centered on the
+ * button/touch that opened it — null means "use the default centered
+ * layout." Set once per open (tap resets it to null, long-press anchors it
+ * to the touch x) — not updated live during a drag: the anchor is fixed,
+ * only the knob moves within the now-stationary track as fill/volume
+ * changes (same delta-based volume calc as always).
+ */
+export const audioTrackAnchorAtom = atom<AudioTrackAnchor | null>(null);

--- a/apps/react-drm/linux-touchbar-control-center/store/brightness.ts
+++ b/apps/react-drm/linux-touchbar-control-center/store/brightness.ts
@@ -1,0 +1,10 @@
+import { atom } from 'jotai';
+import { readBrightness, DISPLAY_DEVICE } from '@/lib/services/brightness';
+
+/**
+ * Live display brightness (0–1), shared between the brightness slider layer
+ * and the splitted layer's brightness button (long-press-and-drag reads/
+ * writes this directly, without waiting for the slider to mount). Keyboard
+ * backlight has no quick-access control yet, so it stays local to the layer.
+ */
+export const displayBrightnessAtom = atom<number>(readBrightness(DISPLAY_DEVICE));

--- a/apps/react-drm/linux-touchbar-control-center/store/volume.ts
+++ b/apps/react-drm/linux-touchbar-control-center/store/volume.ts
@@ -1,0 +1,9 @@
+import { atom } from 'jotai';
+import { readVolume } from '@/lib/services/volume';
+
+/**
+ * Live system volume (0–1), shared between the audio slider layer and the
+ * splitted layer's volume button (long-press-and-drag reads/writes this
+ * directly, without waiting for the slider to mount).
+ */
+export const volumeAtom = atom<number>(readVolume());

--- a/apps/react-drm/src/components/Button.tsx
+++ b/apps/react-drm/src/components/Button.tsx
@@ -31,6 +31,10 @@ export interface ButtonProps {
   activeStyle?: Style;
   children?: React.ReactNode;
   onClick?:      () => void;
+  /** Fires once the button has been held for `longPressDelay`. Suppresses the onClick that would otherwise fire on release. */
+  onLongPress?:  () => void;
+  /** Hold duration in ms before onLongPress fires. Default: 500. */
+  longPressDelay?: number;
   onTouchStart?: (x: number, y: number) => void;
   onTouchMove?:  (x: number, y: number) => void;
   onTouchEnd?:   (x: number, y: number) => void;
@@ -54,6 +58,8 @@ export function Button({
   style,
   activeStyle,
   onClick,
+  onLongPress,
+  longPressDelay = 500,
   onTouchStart,
   onTouchMove,
   onTouchEnd,
@@ -67,6 +73,8 @@ export function Button({
   const id      = useRef(Symbol());
   const nodeRef = useRef<BoxNode | null>(null);
   const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressFiredRef = useRef(false);
 
   useLayoutEffect(() => {
     if (!registry) return;
@@ -88,10 +96,22 @@ export function Button({
       // never lights it up; the registry cancels us before the delay elapses.
       onTouchStart: (tx, ty) => {
         pressTimerRef.current = setTimeout(() => { pressTimerRef.current = null; setActive(true); }, 80);
+        longPressFiredRef.current = false;
+        if (onLongPress) {
+          longPressTimerRef.current = setTimeout(() => {
+            longPressTimerRef.current = null;
+            longPressFiredRef.current = true;
+            onLongPress();
+          }, longPressDelay);
+        }
         onTouchStart?.(tx, ty);
       },
       // Fire the action when the finger lifts (registry checks bounds before calling).
-      onClick: () => { onClick?.(); },
+      // Skipped if a long press already fired for this touch.
+      onClick: () => {
+        if (longPressFiredRef.current) { longPressFiredRef.current = false; return; }
+        onClick?.();
+      },
       onTouchMove,
       // Reset highlight shortly after lift; taps quicker than the press delay
       // still get a brief flash of feedback.
@@ -101,12 +121,15 @@ export function Button({
           pressTimerRef.current = null;
           setActive(true);
         }
+        if (longPressTimerRef.current) { clearTimeout(longPressTimerRef.current); longPressTimerRef.current = null; }
         setTimeout(() => setActive(false), 100);
         onTouchEnd?.(tx, ty);
       },
       // Gesture turned into a scroll/drag — never show (or immediately drop) the highlight.
       onTouchCancel: () => {
         if (pressTimerRef.current) { clearTimeout(pressTimerRef.current); pressTimerRef.current = null; }
+        if (longPressTimerRef.current) { clearTimeout(longPressTimerRef.current); longPressTimerRef.current = null; }
+        longPressFiredRef.current = false;
         setActive(false);
         onTouchCancel?.();
       },


### PR DESCRIPTION
this adds push-hold-slide functionality to quickly change volume and display brightness.
It is a manual merge of upstream commit 4b2a04e and 5be8e8a from https://github.com/dev-muhammad-adel/react-drm-for-touchbar