### PR TITLE
dsp: Add wireplumber and udev config

### DIFF
--- a/modules/t2bce_audio-dsp/99-t2-audio-rename.rules
+++ b/modules/t2bce_audio-dsp/99-t2-audio-rename.rules
@@ -1,0 +1,1 @@
+SUBSYSTEMS=="sound", DEVPATH=="/devices/pci0000:00/*/*/t2bce_audio/t2bce_audio/card?", PROGRAM="/usr/bin/cat /sys/class/dmi/id/product_name", ATTR{id}="t2-%c"

--- a/modules/t2bce_audio-dsp/wireplumber.conf
+++ b/modules/t2bce_audio-dsp/wireplumber.conf
@@ -1,0 +1,243 @@
+monitor.alsa.rules = [
+    {
+        matches = [
+            { alsa.id = "~t2-.*", api.alsa.pcm.stream = "playback" }
+        ]
+        actions = {
+            update-props = {
+                audio.allowed-rates = [96000, 88200, 48000, 44100]
+                node.name = "alsa_output.platform-sound.RawSpeakers"
+                node.description = "Raw Speaker Device (do not use)"
+                node.nick = "RawSpeakers"
+            }
+        }
+    }
+    {
+        matches = [
+            { alsa.id = "~t2-.*", api.alsa.pcm.stream = "capture" }
+        ]
+        actions = {
+            update-props = {
+                node.name = "alsa_input.platform-sound.RawMics"
+                node.description = "Raw Mic Device (do not use)"
+                node.nick = "RawMics"
+            }
+        }
+    }
+]
+
+node.software-dsp.rules = [
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro15,1", api.alsa.pcm.stream = "playback" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/15_1/graph.json"
+                hide-parent = true
+            }
+        }
+    }
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro15,1", api.alsa.pcm.stream = "capture" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/15_1/mic.json"
+                hide-parent = true
+            }
+        }
+    }
+
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro15,4", api.alsa.pcm.stream = "playback" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/15_4/graph.json"
+                hide-parent = true
+            }
+        }
+    }
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro15,4", api.alsa.pcm.stream = "capture" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/15_4/mic.json"
+                hide-parent = true
+            }
+        }
+    }
+
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro16,1", api.alsa.pcm.stream = "playback" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/16_1/graph.json"
+                hide-parent = true
+            }
+        }
+    }
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro16,1", api.alsa.pcm.stream = "capture" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/16_1/mic.json"
+                hide-parent = true
+            }
+        }
+    }
+
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro16,2", api.alsa.pcm.stream = "playback" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/16_2/graph.json"
+                hide-parent = true
+            }
+        }
+    }
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro16,2", api.alsa.pcm.stream = "capture" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/16_2/mic.json"
+                hide-parent = true
+            }
+        }
+    }
+
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro16,3", api.alsa.pcm.stream = "playback" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/16_3/graph.json"
+                hide-parent = true
+            }
+        }
+    }
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro16,3", api.alsa.pcm.stream = "capture" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/16_3/mic.json"
+                hide-parent = true
+            }
+        }
+    }
+
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro16,4", api.alsa.pcm.stream = "playback" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/16_4/graph.json"
+                hide-parent = true
+            }
+        }
+    }
+    {
+        matches = [
+            { alsa.id = "t2-MacBookPro16,4", api.alsa.pcm.stream = "capture" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/16_4/mic.json"
+                hide-parent = true
+            }
+        }
+    }
+
+    {
+        matches = [
+            { alsa.id = "t2-MacBookAir8,1", api.alsa.pcm.stream = "playback" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/8_1/graph.json"
+                hide-parent = true
+            }
+        }
+    }
+    {
+        matches = [
+            { alsa.id = "t2-MacBookAir8,1", api.alsa.pcm.stream = "capture" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/8_1/mic.json"
+                hide-parent = true
+            }
+        }
+    }
+
+    {
+        matches = [
+            { alsa.id = "t2-MacBookAir8,2", api.alsa.pcm.stream = "playback" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/8_2/graph.json"
+                hide-parent = true
+            }
+        }
+    }
+    {
+        matches = [
+            { alsa.id = "t2-MacBookAir8,2", api.alsa.pcm.stream = "capture" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/8_2/mic.json"
+                hide-parent = true
+            }
+        }
+    }
+
+    {
+        matches = [
+            { alsa.id = "t2-MacBookAir9,1", api.alsa.pcm.stream = "playback" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/9_1/graph.json"
+                hide-parent = true
+            }
+        }
+    }
+    {
+        matches = [
+            { alsa.id = "t2-MacBookAir9,1", api.alsa.pcm.stream = "capture" }
+        ]
+        actions = {
+            create-filter = {
+                filter-path = "/usr/share/t2linux-audio/9_1/mic.json"
+                hide-parent = true
+            }
+        }
+    }
+]
+
+
+wireplumber.profiles = {
+    main = {
+        node.software-dsp = required
+    }
+}


### PR DESCRIPTION
the fir dir should be installed to `/usr/share/t2linux-audio` for the wireplumber config to work.