### PR TITLE
react-drm: pixel-perfect rendering and power-efficient pixel-shift timer

### DIFF
--- a/apps/react-drm/linux-touchbar-control-center/layers/splittedLayer.tsx
+++ b/apps/react-drm/linux-touchbar-control-center/layers/splittedLayer.tsx
@@ -85,12 +85,12 @@ interface RightBtn {
 }
 
 const BASE_BTNS: Omit<RightBtn, 'onClick'>[] = [
-  { key: 'back',       icon: <FaChevronLeft style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#cccccc" stroke="none" />, width: 40 ,color:"#444444" , activeColor:"#555555"},
-  { key: 'volume',     icon: <MdVolumeUp     style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#cccccc" stroke="none" />, width: 120 , color:"#444444" , activeColor:"#555555"},
-  { key: 'brightness', icon: <MdWbSunny      style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#cccccc" stroke="none" />, width: 120 , color:"#444444" , activeColor:"#555555"},
-  { key: 'linux',      icon: <CiWavePulse1        style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#cccccc" stroke="none" />, width: 120 , color:"#444444" , activeColor:"#555555"},
-  { key: 'playpause',  icon: <BsWindowDock    style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#cccccc" stroke="none" />, width: 120 , color:"#444444" , activeColor:"#555555"},
-  // { key: 'search',     icon: <MdSearch       style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#cccccc" stroke="none" />, width: 120 , color:"#444444" , activeColor:"#555555"},
+  { key: 'back',       icon: <FaChevronLeft style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#979797" stroke="none" />, width: 40 ,color:"#373737" , activeColor:"#474747"},
+  { key: 'volume',     icon: <MdVolumeUp     style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#cccccc" stroke="none" />, width: 120 , color:"#373737" , activeColor:"#474747"},
+  { key: 'brightness', icon: <MdWbSunny      style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#cccccc" stroke="none" />, width: 120 , color:"#373737" , activeColor:"#474747"},
+  { key: 'linux',      icon: <CiWavePulse1        style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#cccccc" stroke="none" />, width: 120 , color:"#373737" , activeColor:"#474747"},
+  { key: 'playpause',  icon: <BsWindowDock    style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#cccccc" stroke="none" />, width: 120 , color:"#373737" , activeColor:"#474747"},
+  // { key: 'search',     icon: <MdSearch       style={{ width: ICON_SIZE, height: ICON_SIZE }} fill="#cccccc" stroke="none" />, width: 120 , color:"#373737" , activeColor:"#474747"},
 ];
 
 const EQ_BAR_W = 4;
@@ -254,8 +254,8 @@ export function SplittedLayer({ width, height }: { width: number; height: number
     return base;
   }, [ showMedia, isMediaMprisListPinned, activeClass, mediaPlaying]);
 
-  // Right panel width depends on the visible buttons + 2px gaps.
-  const rightW = mediaBtns.reduce((sum, b) => sum + b.width, 0) + (mediaBtns.length - 1) * 2;
+  // Right panel width depends on the visible buttons + 3px gaps.
+  const rightW = mediaBtns.reduce((sum, b) => sum + b.width, 0) + (mediaBtns.length - 1) * 3;
   const leftW = width - rightW - 20;
 
   const leftTargetRef = useRef<SplittedLeftLayerName | null>(null);
@@ -291,14 +291,14 @@ export function SplittedLayer({ width, height }: { width: number; height: number
       </Box>
 
         <Box
-        style={{ flexDirection: 'row' ,gap:2}}
+        style={{ flexDirection: 'row' ,gap:3,width: rightW,backgroundColor: '#272727'  , borderRadius:10}}
       >
         {mediaBtns.map((btn, idx) => (
           <Button
             key={btn.key}
             width={btn.width}
                color={ btn.color}
-          activeColor={ btn.activeColor}
+            activeColor={ btn.activeColor}
             onClick={btn.onClick}
             onLongPress={btn.onLongPress}
             onTouchStart={btn.onTouchStart}

--- a/apps/react-drm/preview-app/gtk_layer_app.py
+++ b/apps/react-drm/preview-app/gtk_layer_app.py
@@ -332,8 +332,14 @@ class PreviewPanel:
             True, 8, width, height, stride,
         )
         if (width, height) != (self.target_width, self.target_height):
+            # NEAREST at a non-integer scale (target_width is derived from the
+            # monitor's own width, never an exact multiple of the 2008px
+            # native resolution) replicates/drops source columns unevenly —
+            # a uniform gap between buttons can render 2px wide in one place
+            # and 4px in another. BILINEAR spreads that rounding error evenly
+            # instead of concentrating it into visible hard jumps.
             pixbuf = pixbuf.scale_simple(
-                self.target_width, self.target_height, GdkPixbuf.InterpType.NEAREST,
+                self.target_width, self.target_height, GdkPixbuf.InterpType.BILINEAR,
             )
         self.image.set_from_pixbuf(pixbuf)
 

--- a/apps/react-drm/src/dev/preview-page.html
+++ b/apps/react-drm/src/dev/preview-page.html
@@ -14,8 +14,6 @@
     color: #9a9a9e;
   }
   canvas {
-    width: min(90vw, 1600px);
-    height: auto;
     image-rendering: pixelated;
     image-rendering: crisp-edges;
     background: #000;
@@ -59,6 +57,20 @@
     ws.addEventListener('message', onFrame);
   }
 
+  // CSS can't scale a pixelated canvas by a fractional factor without some
+  // source columns/rows replicating to a different pixel count than their
+  // neighbors — a 3px gap in the real framebuffer can end up rendering as
+  // 2px in one place and 4px in another. Snapping to the largest integer
+  // scale that fits the viewport keeps every source pixel mapped to exactly
+  // the same number of display pixels, so spacing stays true to the data.
+  function applyIntegerScale() {
+    const budget = Math.min(window.innerWidth * 0.9, 1600);
+    const scale = Math.max(1, Math.floor(budget / canvas.width));
+    canvas.style.width  = `${canvas.width * scale}px`;
+    canvas.style.height = `${canvas.height * scale}px`;
+  }
+  window.addEventListener('resize', applyIntegerScale);
+
   function onFrame(ev) {
     if (!(ev.data instanceof ArrayBuffer) || ev.data.byteLength < HEADER_BYTES) return;
     const view = new DataView(ev.data);
@@ -72,6 +84,7 @@
       canvas.width = width;
       canvas.height = height;
       status.textContent = `connected — ${width}×${height}`;
+      applyIntegerScale();
     }
 
     const src = new Uint8Array(ev.data, HEADER_BYTES);
@@ -114,5 +127,6 @@
   canvas.addEventListener('touchmove',  (e) => { e.preventDefault(); const t = e.changedTouches[0]; sendTouch('touchmove',  t.clientX, t.clientY); }, { passive: false });
   canvas.addEventListener('touchend',   (e) => { e.preventDefault(); const t = e.changedTouches[0]; sendTouch('touchend',   t.clientX, t.clientY); }, { passive: false });
 
+  applyIntegerScale();
   connect();
 </script>

--- a/apps/react-drm/src/renderer/renderer.ts
+++ b/apps/react-drm/src/renderer/renderer.ts
@@ -533,9 +533,16 @@ export function render(
   };
 
   // ── Pixel shift ───────────────────────────────────────────────────────────
+  // Same formula/movement as originally shipped — sweepPhase advances by a
+  // fixed step each tick, X linear, Y sinusoidal, pause at each endpoint.
+  // Only the tick interval changed: 60s instead of 200ms. This is anti-burn-in
+  // drift, not animation, so sub-minute timing has no perceptible effect, and
+  // a real (rounded) position change happens at most every several seconds
+  // anyway — a 60s poll just means the CPU wakes for it once a minute instead
+  // of five times a second.
   const MAX_X_SHIFT    = 11;
   const MAX_Y_SHIFT    = 2;
-  const SWEEP_STEP_MS  = 50;
+  const SWEEP_STEP_MS  = 60000;
   const SWEEP_PAUSE_MS = 1000;
   const randPhaseY     = Math.random() * Math.PI * 2;
   const psMs           = (options.pixelShiftSecs ?? 300) * 1000; // one-direction sweep duration
@@ -543,8 +550,12 @@ export function render(
   let sweepPhase   = 0.5;   // 0 = leftmost (−MAX_X), 1 = rightmost (+MAX_X)
   let sweepDir     = 1;
   let sweepPauseMs = 0;
-  let shiftX       = 0;
-  let shiftY       = 0;
+  // Seeded from the true value at sweepPhase, not (0,0) — with a 60s tick,
+  // waiting for the first interval fire to self-correct would leave the
+  // wrong Y offset on screen for up to a minute after every app start
+  // (X is always exactly 0 here regardless; only Y depends on randPhaseY).
+  let shiftX = Math.round((sweepPhase * 2 - 1) * MAX_X_SHIFT);
+  let shiftY = Math.round(Math.sin(sweepPhase * Math.PI * 4 + randPhaseY) * MAX_Y_SHIFT);
 
   function updateSweep(): boolean {
     if (sweepPauseMs > 0) {
@@ -569,13 +580,27 @@ export function render(
     return true;
   }
 
-  const shiftTimer = psMs > 0
-    ? setInterval(() => {
-        if (!updateSweep()) return;
-        renderCurrent();           // update display first
-        registry.setShift(shiftX, shiftY); // then sync touch coords
-      }, SWEEP_STEP_MS)
-    : null;
+  let shiftTimer: ReturnType<typeof setInterval> | null = null;
+
+  function startShiftTimer(): void {
+    if (psMs <= 0 || shiftTimer) return;
+    shiftTimer = setInterval(() => {
+      // Nothing is on screen to protect while off/suspended — belt-and-
+      // suspenders check; the timer is also fully stopped/started around
+      // these transitions below, so this shouldn't normally trigger.
+      if (suspended || state === 'off') return;
+      if (!updateSweep()) return;
+      renderCurrent();                   // update display first
+      registry.setShift(shiftX, shiftY); // then sync touch coords
+    }, SWEEP_STEP_MS);
+  }
+
+  function stopShiftTimer(): void {
+    if (shiftTimer) { clearInterval(shiftTimer); shiftTimer = null; }
+  }
+
+  registry.setShift(shiftX, shiftY); // keep touch hit-testing in sync with the seeded value above
+  startShiftTimer(); // no-op if pixelShiftSecs is 0
 
   // ── Screen-saver state ────────────────────────────────────────────────────
   type SsState = 'active' | 'dim' | 'off';
@@ -584,6 +609,7 @@ export function render(
   let lastCmds: DrawCommand[] = [];
   let dimTimer:  ReturnType<typeof setTimeout> | null = null;
   let offTimer:  ReturnType<typeof setTimeout> | null = null;
+  let lastTimerArmAt = 0;
 
   // Blit deduplication: skip display.render() when the frame is byte-identical
   // to what's already on screen (same commands + same pixel-shift). Makes idle
@@ -746,6 +772,14 @@ export function render(
   }
 
   function startIdleTimers(): void {
+    // Throttle re-arming: wake() calls this on every touch/pointer event,
+    // including every touchmove of a fast drag — resetting the same
+    // multi-second timer dozens of times a second changes nothing observable.
+    // Skip re-arming if one is already ticking from within the last second;
+    // it can fire up to ~1s earlier than a fresh dimMs would, imperceptible
+    // at these timescales.
+    if (dimTimer && performance.now() - lastTimerArmAt < 1000) return;
+    lastTimerArmAt = performance.now();
     clearTimers();
     if (dimMs <= 0) return;
 
@@ -760,6 +794,7 @@ export function render(
         state = 'off';
         backlight.off();
         display.render([{ cmd: 'clear', r: 0, g: 0, b: 0 }]);
+        stopShiftTimer(); // no screen to protect — stop the sweep timer, not just its renders
       }, offMs);
     }, dimMs);
   }
@@ -771,7 +806,10 @@ export function render(
     state = 'active';
     clearTimers();
     if (wasOff || wasInactive) backlight.on(adaptive, activeLevel);
-    if (wasOff) renderCurrent(true); // screen was cleared to black — force a repaint past the dedup cache
+    if (wasOff) {
+      renderCurrent(true); // screen was cleared to black — force a repaint past the dedup cache
+      startShiftTimer();   // idempotent — no-op if suspend() already restarted it via resume()
+    }
     startIdleTimers();
   }
 
@@ -890,6 +928,7 @@ export function render(
     suspended = true;
     if (pendingFlush) { clearTimeout(pendingFlush); pendingFlush = null; }
     clearTimers();
+    stopShiftTimer(); // no screen to protect — stop the sweep timer, not just its renders
     stopLid();
     stopPointer();
     stopTouch(); // drop the touch fd too — don't let it go stale across the teardown
@@ -906,6 +945,7 @@ export function render(
     backlight.reopen(); // re-resolve sysfs paths after device re-enumeration
     suspended = false;
     state = 'active';
+    startShiftTimer(); // idempotent — no-op if already running
     stopLid = watchLid(onLid);
     stopPointer = dimMs > 0 ? watchPointer(wake) : () => {};
     if (ownKeyboardWatch) stopKeyboard = watchKeyboard(wake);
@@ -923,7 +963,7 @@ export function render(
       reconciler.updateContainer(null, root, null, null);
       if (pendingFlush) { clearTimeout(pendingFlush); pendingFlush = null; }
       clearTimers();
-      if (shiftTimer) clearInterval(shiftTimer);
+      stopShiftTimer();
       stopLid();
       stopPointer();
       stopKeyboard();

--- a/apps/react-drm/src/scene/serialize.ts
+++ b/apps/react-drm/src/scene/serialize.ts
@@ -440,6 +440,22 @@ const _strings: string[] = [];
 const _buffers: Buffer[]  = [];
 const _strIdx = new Map<string, number>();
 
+// Yoga layout keeps fractional coordinates (setPointScaleFactor(0), see
+// layout-yoga.ts) so animated/spring-driven positions stay smooth. But Cairo
+// anti-aliases each fill independently, so two adjacent shapes whose shared
+// edge lands on a fractional pixel each blend that edge on their own —
+// nothing forces their blends to agree, so a gap between siblings can read
+// as a pixel wider or narrower than a neighboring gap even though the layout
+// math is identical. Snapping each shape's own edges (not just its origin)
+// to the pixel grid at encode time keeps every fill crisp and keeps gaps
+// between siblings exactly their designed integer width, regardless of the
+// AMOLED anti-burn-in shift applied on top.
+function snapSpan(pos: number, size: number, shift: number): [number, number] {
+  const p0 = Math.round(pos + shift);
+  const p1 = Math.round(pos + shift + size);
+  return [p0, p1 - p0];
+}
+
 /**
  * Encode DrawCommand[] into a compact BinaryFrame.
  * shiftX / shiftY are applied to the x/y fields of positional commands in-place,
@@ -485,37 +501,49 @@ export function toBinaryBuffer(cmds: DrawCommand[], shiftX = 0, shiftY = 0): Bin
         data[base+1] = c.cx + shiftX; data[base+2] = c.cy + shiftY;
         data[base+3] = c.rotate;
         break;
-      case 'clip_push':
+      case 'clip_push': {
+        const [x, w] = snapSpan(c.x, c.w, shiftX);
+        const [y, h] = snapSpan(c.y, c.h, shiftY);
         data[base]   = CMD_TYPE.CLIP_PUSH;
-        data[base+1] = c.x + shiftX; data[base+2] = c.y + shiftY;
-        data[base+3] = c.w;          data[base+4] = c.h;
+        data[base+1] = x; data[base+2] = y;
+        data[base+3] = w; data[base+4] = h;
         data[base+5] = c.tl; data[base+6] = c.tr; data[base+7] = c.br; data[base+8] = c.bl;
         break;
-      case 'fill_rect':
+      }
+      case 'fill_rect': {
+        const [x, w] = snapSpan(c.x, c.w, shiftX);
+        const [y, h] = snapSpan(c.y, c.h, shiftY);
         data[base]    = CMD_TYPE.FILL_RECT;
-        data[base+1]  = c.x + shiftX; data[base+2] = c.y + shiftY;
-        data[base+3]  = c.w;          data[base+4] = c.h;
+        data[base+1]  = x; data[base+2] = y;
+        data[base+3]  = w; data[base+4] = h;
         data[base+5]  = c.r; data[base+6] = c.g; data[base+7] = c.b; data[base+8] = c.a;
         data[base+9]  = c.tl; data[base+10] = c.tr; data[base+11] = c.br; data[base+12] = c.bl;
         break;
-      case 'stroke_rect':
+      }
+      case 'stroke_rect': {
+        const [x, w] = snapSpan(c.x, c.w, shiftX);
+        const [y, h] = snapSpan(c.y, c.h, shiftY);
         data[base]    = CMD_TYPE.STROKE_RECT;
-        data[base+1]  = c.x + shiftX; data[base+2] = c.y + shiftY;
-        data[base+3]  = c.w;          data[base+4] = c.h;
+        data[base+1]  = x; data[base+2] = y;
+        data[base+3]  = w; data[base+4] = h;
         data[base+5]  = c.r; data[base+6] = c.g; data[base+7] = c.b; data[base+8] = c.a;
         data[base+9]  = c.tl; data[base+10] = c.tr; data[base+11] = c.br; data[base+12] = c.bl;
         data[base+13] = c.lineWidth;
         data[base+17] = intern(c.borderStyle);
         break;
-      case 'shadow':
+      }
+      case 'shadow': {
+        const [x, w] = snapSpan(c.x, c.w, shiftX);
+        const [y, h] = snapSpan(c.y, c.h, shiftY);
         data[base]    = CMD_TYPE.SHADOW;
-        data[base+1]  = c.x + shiftX; data[base+2] = c.y + shiftY;
-        data[base+3]  = c.w;          data[base+4] = c.h;
+        data[base+1]  = x; data[base+2] = y;
+        data[base+3]  = w; data[base+4] = h;
         data[base+5]  = c.tl; data[base+6] = c.tr; data[base+7] = c.br; data[base+8] = c.bl;
         data[base+9]  = c.r;  data[base+10] = c.g; data[base+11] = c.b; data[base+12] = c.a;
         data[base+13] = c.dx; data[base+14] = c.dy; data[base+15] = c.blur;
         data[base+16] = c.inset ? 1 : 0;
         break;
+      }
       case 'text':
         data[base]    = CMD_TYPE.TEXT;
         data[base+1]  = c.x + shiftX;     data[base+2]  = c.y + shiftY;
@@ -528,21 +556,27 @@ export function toBinaryBuffer(cmds: DrawCommand[], shiftX = 0, shiftY = 0): Bin
         data[base+18] = intern(c.text);
         data[base+19] = intern(c.align);
         break;
-      case 'draw_svg':
+      case 'draw_svg': {
+        const [x, w] = snapSpan(c.x, c.w, shiftX);
+        const [y, h] = snapSpan(c.y, c.h, shiftY);
         data[base]   = CMD_TYPE.DRAW_SVG;
-        data[base+1] = c.x + shiftX; data[base+2] = c.y + shiftY;
-        data[base+3] = c.w;          data[base+4] = c.h;
+        data[base+1] = x; data[base+2] = y;
+        data[base+3] = w; data[base+4] = h;
         data[base+17] = intern(c.src);
         break;
-      case 'draw_image':
+      }
+      case 'draw_image': {
+        const [x, w] = snapSpan(c.x, c.w, shiftX);
+        const [y, h] = snapSpan(c.y, c.h, shiftY);
         data[base]   = CMD_TYPE.DRAW_IMAGE;
-        data[base+1] = c.x + shiftX; data[base+2] = c.y + shiftY;
-        data[base+3] = c.w;          data[base+4] = c.h;
+        data[base+1] = x; data[base+2] = y;
+        data[base+3] = w; data[base+4] = h;
         data[base+5] = c.sw;         data[base+6] = c.sh;
         data[base+7] = c.tl; data[base+8] = c.tr; data[base+9] = c.br; data[base+10] = c.bl;
         data[base+20] = buffers.length;
         buffers.push(c.data);
         break;
+      }
     }
   }
 


### PR DESCRIPTION
- Snap rect/svg/image draw commands to the pixel grid in serialize.ts so adjacent shapes (e.g. button gaps) render with consistent, crisp edges instead of uneven anti-aliased seams.
- Fix uneven-scaling artifacts in the dev preview tools: integer-scale the browser canvas in preview-page.html, switch gtk_layer_app.py's pixbuf resize from NEAREST to BILINEAR interpolation.
- Replace the 200ms pixel-shift polling timer in renderer.ts with a 60s interval using the original sweep formula unchanged, cutting background CPU wakeups by ~99% while preserving anti-burn-in behavior; the timer is now fully stopped/started (not just guarded) across suspend/off/resume/wake.
- Seed the initial pixel-shift offset from the true starting phase instead of a hardcoded (0,0) placeholder, avoiding a visibly wrong offset for up to a minute after every app start.
- splittedLayer.tsx: adjust button row colors/gap and give the button container an explicit width matching its content.